### PR TITLE
fix: restore full landing page, remove coming-soon placeholder

### DIFF
--- a/app/download/page.tsx
+++ b/app/download/page.tsx
@@ -50,7 +50,7 @@ export default function DownloadPage() {
             </div>
 
             <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold text-white leading-tight mb-6">
-              You're Moments Away From Solving Families' Biggest Pain Point
+              You&apos;re Moments Away From Solving Families&apos; Biggest Pain Point
             </h1>
 
             <p className="text-xl text-blue-100 mb-8">
@@ -133,7 +133,7 @@ export default function DownloadPage() {
                   <div className="flex items-center justify-between">
                     <div>
                       <p className="text-xs text-gray-500">Good morning,</p>
-                      <p className="font-bold text-sm">Emma's Tasks</p>
+                      <p className="font-bold text-sm">Emma&apos;s Tasks</p>
                     </div>
                     <div className="w-8 h-8 bg-[#FFC300] rounded-full flex items-center justify-center text-sm">
                       👧
@@ -149,7 +149,7 @@ export default function DownloadPage() {
 
                   {/* Tasks */}
                   <div>
-                    <p className="text-xs font-semibold text-gray-500 mb-2">Today's Tasks</p>
+                    <p className="text-xs font-semibold text-gray-500 mb-2">Today&apos;s Tasks</p>
                     {[
                       { task: "Clean bedroom", points: 15, status: "done" },
                       { task: "Math homework", points: 20, status: "pending" },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -61,10 +61,7 @@ export default function Home() {
             </div>
 
             <div className="hidden md:flex items-center space-x-4">
-              <button className="px-4 py-2 text-[#3A7BFA] font-medium hover:bg-blue-50 rounded-lg transition-colors">
-                Sign In
-              </button>
-              <a 
+              <a
                 href="/download"
                 className="px-4 py-2 bg-[#3A7BFA] text-white font-medium rounded-lg hover:bg-blue-600 transition-colors"
               >
@@ -92,8 +89,7 @@ export default function Home() {
               <button onClick={() => scrollToSection("features")} className="block w-full text-left py-2 text-gray-600">Features</button>
               <button onClick={() => scrollToSection("pricing")} className="block w-full text-left py-2 text-gray-600">Pricing</button>
               <button onClick={() => scrollToSection("faq")} className="block w-full text-left py-2 text-gray-600">FAQ</button>
-              <div className="pt-3 border-t border-gray-100 space-y-2">
-                <button className="w-full py-2 text-[#3A7BFA] font-medium">Sign In</button>
+              <div className="pt-3 border-t border-gray-100">
                 <a href="/download" className="block w-full py-2 bg-[#3A7BFA] text-white font-medium rounded-lg text-center">Start Free Trial</a>
               </div>
             </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -202,7 +202,7 @@ export default function Home() {
                     </div>
                     <div>
                       <h4 className="font-bold text-lg mb-1">Photo Proof Required</h4>
-                      <p className="text-gray-600">Kids must submit photo evidence. No more "I did it" without verification.</p>
+                      <p className="text-gray-600">Kids must submit photo evidence. No more &quot;I did it&quot; without verification.</p>
                     </div>
                   </div>
                   <div className="flex items-start space-x-4">
@@ -405,7 +405,7 @@ export default function Home() {
                     <Star key={i} className="w-5 h-5 text-[#FFC300] fill-[#FFC300]" />
                   ))}
                 </div>
-                <p className="text-gray-700 mb-4 italic">"{testimonial.quote}"</p>
+                <p className="text-gray-700 mb-4 italic">&quot;{testimonial.quote}&quot;</p>
                 <div>
                   <p className="font-semibold text-[#1C1F26]">{testimonial.author}</p>
                   <p className="text-sm text-gray-500">{testimonial.detail}</p>
@@ -574,7 +574,7 @@ export default function Home() {
           >
             <h2 className="text-3xl sm:text-4xl font-bold mb-4">Ready to End the Screen Time Fights?</h2>
             <p className="text-xl text-blue-100 mb-8 max-w-2xl mx-auto">
-              Join thousands of families who've transformed screen time from a battle into motivation.
+              Join thousands of families who&apos;ve transformed screen time from a battle into motivation.
             </p>
             <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
               <motion.a 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -72,9 +72,12 @@ export default function Home() {
               </a>
             </div>
 
-            <button 
+            <button
               className="md:hidden p-2"
               onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+              aria-label={mobileMenuOpen ? "Close navigation menu" : "Open navigation menu"}
+              aria-expanded={mobileMenuOpen}
+              aria-controls="mobile-navigation"
             >
               {mobileMenuOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
             </button>
@@ -83,7 +86,7 @@ export default function Home() {
 
         {/* Mobile Menu */}
         {mobileMenuOpen && (
-          <div className="md:hidden bg-white border-t border-gray-100">
+          <div id="mobile-navigation" className="md:hidden bg-white border-t border-gray-100">
             <div className="px-4 py-4 space-y-3">
               <button onClick={() => scrollToSection("how-it-works")} className="block w-full text-left py-2 text-gray-600">How It Works</button>
               <button onClick={() => scrollToSection("features")} className="block w-full text-left py-2 text-gray-600">Features</button>
@@ -544,15 +547,23 @@ export default function Home() {
               >
                 <button
                   className="w-full px-6 py-4 text-left flex items-center justify-between hover:bg-gray-50 transition-colors"
+                  id={`faq-button-${index}`}
+                  aria-expanded={openFaq === index}
+                  aria-controls={`faq-panel-${index}`}
                   onClick={() => setOpenFaq(openFaq === index ? null : index)}
                 >
                   <span className="font-semibold text-[#1C1F26]">{faq.q}</span>
-                  <ChevronDown 
-                    className={`w-5 h-5 text-gray-400 transition-transform ${openFaq === index ? 'rotate-180' : ''}`} 
+                  <ChevronDown
+                    className={`w-5 h-5 text-gray-400 transition-transform ${openFaq === index ? 'rotate-180' : ''}`}
                   />
                 </button>
                 {openFaq === index && (
-                  <div className="px-6 pb-4 text-gray-600">
+                  <div
+                    id={`faq-panel-${index}`}
+                    role="region"
+                    aria-labelledby={`faq-button-${index}`}
+                    className="px-6 pb-4 text-gray-600"
+                  >
                     {faq.a}
                   </div>
                 )}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,42 +1,637 @@
+"use client";
+
+import { motion } from "framer-motion";
+import {
+  Camera,
+  Clock,
+  Gift,
+  CheckCircle,
+  Star,
+  Zap,
+  Smartphone,
+  Lock,
+  Shield,
+  ChevronDown,
+  Menu,
+  X
+} from "lucide-react";
+import { useState } from "react";
 import Image from "next/image";
+import Link from "next/link";
+
+const fadeInUp = {
+  initial: { opacity: 0, y: 20 },
+  animate: { opacity: 1, y: 0 },
+  transition: { duration: 0.5 }
+};
+
+const staggerContainer = {
+  animate: {
+    transition: {
+      staggerChildren: 0.1
+    }
+  }
+};
 
 export default function Home() {
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [openFaq, setOpenFaq] = useState<number | null>(null);
+
+  const scrollToSection = (id: string) => {
+    document.getElementById(id)?.scrollIntoView({ behavior: "smooth" });
+    setMobileMenuOpen(false);
+  };
+
   return (
-    <div className="min-h-screen bg-gradient-to-br from-[#3A7BFA] via-[#2563EB] to-[#1d4ed8] flex flex-col items-center justify-center px-4 relative overflow-hidden">
-      {/* Background decorations */}
-      <div className="absolute inset-0 opacity-10 pointer-events-none">
-        <div className="absolute top-20 left-10 w-64 h-64 bg-white rounded-full blur-3xl" />
-        <div className="absolute bottom-20 right-10 w-96 h-96 bg-[#FFC300] rounded-full blur-3xl" />
-      </div>
+    <div className="min-h-screen bg-white">
+      {/* Navigation */}
+      <nav className="fixed top-0 left-0 right-0 z-50 bg-white/80 backdrop-blur-md border-b border-gray-100">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center h-16">
+            <div className="flex items-center space-x-2">
+              <Image src="/logo.svg" alt="Screen Time Hero" width={32} height={32} />
+              <span className="text-xl font-bold text-[#1C1F26]">Screen Time Hero</span>
+            </div>
+            
+            <div className="hidden md:flex items-center space-x-8">
+              <button onClick={() => scrollToSection("how-it-works")} className="text-gray-600 hover:text-[#3A7BFA] transition-colors">How It Works</button>
+              <button onClick={() => scrollToSection("features")} className="text-gray-600 hover:text-[#3A7BFA] transition-colors">Features</button>
+              <button onClick={() => scrollToSection("pricing")} className="text-gray-600 hover:text-[#3A7BFA] transition-colors">Pricing</button>
+              <button onClick={() => scrollToSection("faq")} className="text-gray-600 hover:text-[#3A7BFA] transition-colors">FAQ</button>
+            </div>
 
-      <div className="relative z-10 text-center max-w-2xl">
-        <div className="flex items-center justify-center space-x-3 mb-8">
-          <Image src="/logo.svg" alt="Screen Time Hero" width={56} height={56} />
-          <span className="text-3xl sm:text-4xl font-bold text-white">Screen Time Hero</span>
+            <div className="hidden md:flex items-center space-x-4">
+              <button className="px-4 py-2 text-[#3A7BFA] font-medium hover:bg-blue-50 rounded-lg transition-colors">
+                Sign In
+              </button>
+              <a 
+                href="/download"
+                className="px-4 py-2 bg-[#3A7BFA] text-white font-medium rounded-lg hover:bg-blue-600 transition-colors"
+              >
+                Start Free Trial
+              </a>
+            </div>
+
+            <button 
+              className="md:hidden p-2"
+              onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+            >
+              {mobileMenuOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
+            </button>
+          </div>
         </div>
 
-        <h1 className="text-5xl sm:text-6xl font-bold text-white mb-6">
-          Coming Soon
-        </h1>
+        {/* Mobile Menu */}
+        {mobileMenuOpen && (
+          <div className="md:hidden bg-white border-t border-gray-100">
+            <div className="px-4 py-4 space-y-3">
+              <button onClick={() => scrollToSection("how-it-works")} className="block w-full text-left py-2 text-gray-600">How It Works</button>
+              <button onClick={() => scrollToSection("features")} className="block w-full text-left py-2 text-gray-600">Features</button>
+              <button onClick={() => scrollToSection("pricing")} className="block w-full text-left py-2 text-gray-600">Pricing</button>
+              <button onClick={() => scrollToSection("faq")} className="block w-full text-left py-2 text-gray-600">FAQ</button>
+              <div className="pt-3 border-t border-gray-100 space-y-2">
+                <button className="w-full py-2 text-[#3A7BFA] font-medium">Sign In</button>
+                <a href="/download" className="block w-full py-2 bg-[#3A7BFA] text-white font-medium rounded-lg text-center">Start Free Trial</a>
+              </div>
+            </div>
+          </div>
+        )}
+      </nav>
 
-        <p className="text-xl text-blue-100 mb-8 max-w-lg mx-auto">
-          We&apos;re building something that will end the screen time fights forever. Stay tuned.
-        </p>
-
-        <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-6 inline-block">
-          <p className="text-blue-100 text-sm mb-1">Get notified when we launch</p>
-          <a
-            href="mailto:support@screentimehero.com"
-            className="text-white font-semibold text-lg hover:text-[#FFC300] transition-colors"
+      {/* Hero Section */}
+      <section className="pt-32 pb-20 lg:pt-40 lg:pb-32 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-7xl mx-auto">
+          <motion.div 
+            className="text-center max-w-4xl mx-auto"
+            initial={{ opacity: 0, y: 30 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6 }}
           >
-            support@screentimehero.com
-          </a>
-        </div>
-      </div>
+            <div className="inline-flex items-center space-x-2 bg-[#FFC300]/20 text-[#1C1F26] px-4 py-2 rounded-full text-sm font-medium mb-6">
+              <Star className="w-4 h-4 text-[#FFC300] fill-[#FFC300]" />
+              <span>7-Day Free Trial • No Credit Card Required</span>
+            </div>
+            
+            <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold text-[#1C1F26] leading-tight mb-6">
+              End the Screen Time{" "}
+              <span className="text-[#3A7BFA]">Fights</span>{" "}
+              Forever
+            </h1>
+            
+            <p className="text-xl text-gray-600 mb-8 max-w-2xl mx-auto">
+              Turn screen time battles into motivation. Your kids will actually{" "}
+              <span className="font-semibold text-[#1C1F26]">want</span> to do chores.
+            </p>
 
-      <div className="absolute bottom-6 text-blue-200/50 text-sm">
-        &copy; 2026 Screen Time Hero
-      </div>
+            <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+              <motion.a 
+                href="/download"
+                className="w-full sm:w-auto px-8 py-4 bg-[#3A7BFA] text-white font-semibold rounded-xl text-lg hover:bg-blue-600 transition-colors shadow-lg shadow-blue-500/25 text-center"
+                whileHover={{ scale: 1.02 }}
+                whileTap={{ scale: 0.98 }}
+              >
+                Start Your Free Trial
+              </motion.a>
+              <motion.button 
+                className="w-full sm:w-auto px-8 py-4 bg-white text-[#1C1F26] font-semibold rounded-xl text-lg border-2 border-gray-200 hover:border-[#3A7BFA] hover:text-[#3A7BFA] transition-colors"
+                whileHover={{ scale: 1.02 }}
+                whileTap={{ scale: 0.98 }}
+                onClick={() => scrollToSection("how-it-works")}
+              >
+                See How It Works
+              </motion.button>
+            </div>
+
+            <p className="mt-6 text-sm text-gray-500">
+              Works on iPhone & iPad. Android coming soon.
+            </p>
+          </motion.div>
+
+          {/* App Preview */}
+          <motion.div 
+            className="mt-16 relative"
+            initial={{ opacity: 0, y: 40 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.2 }}
+          >
+            <div className="bg-gradient-to-b from-[#3A7BFA]/5 to-transparent rounded-3xl p-8">
+              <div className="grid md:grid-cols-2 gap-8 items-center">
+                <div className="bg-white rounded-2xl shadow-2xl p-6 border border-gray-100">
+                  <div className="flex items-center justify-between mb-6">
+                    <div>
+                      <h3 className="font-bold text-lg">Parent Dashboard</h3>
+                      <p className="text-sm text-gray-500">3 tasks awaiting approval</p>
+                    </div>
+                    <div className="w-10 h-10 bg-[#FFC300] rounded-full flex items-center justify-center">
+                      <span className="text-lg">👋</span>
+                    </div>
+                  </div>
+                  <div className="space-y-3">
+                    {["Clean bedroom - 15 pts", "Math homework - 20 pts", "Walk the dog - 10 pts"].map((task, i) => (
+                      <div key={i} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
+                        <div className="flex items-center space-x-3">
+                          <Camera className="w-5 h-5 text-[#3A7BFA]" />
+                          <span className="text-sm font-medium">{task}</span>
+                        </div>
+                        <div className="flex space-x-2">
+                          <button className="p-2 bg-[#4CCB6E] text-white rounded-lg">
+                            <CheckCircle className="w-4 h-4" />
+                          </button>
+                          <button className="p-2 bg-gray-200 text-gray-600 rounded-lg">
+                            <X className="w-4 h-4" />
+                          </button>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="space-y-6">
+                  <div className="flex items-start space-x-4">
+                    <div className="w-12 h-12 bg-[#FFC300]/20 rounded-xl flex items-center justify-center flex-shrink-0">
+                      <Zap className="w-6 h-6 text-[#FFC300]" />
+                    </div>
+                    <div>
+                      <h4 className="font-bold text-lg mb-1">Automatic Enforcement</h4>
+                      <p className="text-gray-600">When time runs out, apps automatically lock. No negotiations, no arguments.</p>
+                    </div>
+                  </div>
+                  <div className="flex items-start space-x-4">
+                    <div className="w-12 h-12 bg-[#4CCB6E]/20 rounded-xl flex items-center justify-center flex-shrink-0">
+                      <Camera className="w-6 h-6 text-[#4CCB6E]" />
+                    </div>
+                    <div>
+                      <h4 className="font-bold text-lg mb-1">Photo Proof Required</h4>
+                      <p className="text-gray-600">Kids must submit photo evidence. No more "I did it" without verification.</p>
+                    </div>
+                  </div>
+                  <div className="flex items-start space-x-4">
+                    <div className="w-12 h-12 bg-[#3A7BFA]/20 rounded-xl flex items-center justify-center flex-shrink-0">
+                      <Gift className="w-6 h-6 text-[#3A7BFA]" />
+                    </div>
+                    <div>
+                      <h4 className="font-bold text-lg mb-1">Flexible Rewards</h4>
+                      <p className="text-gray-600">Screen time, cash, privileges, or experiences — customize what motivates your child.</p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </motion.div>
+        </div>
+      </section>
+
+      {/* How It Works */}
+      <section id="how-it-works" className="py-20 bg-[#F4F5F7]">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <motion.div 
+            className="text-center mb-16"
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.5 }}
+          >
+            <h2 className="text-3xl sm:text-4xl font-bold text-[#1C1F26] mb-4">How It Works</h2>
+            <p className="text-xl text-gray-600 max-w-2xl mx-auto">
+              Three simple steps to transform screen time from battle to motivation
+            </p>
+          </motion.div>
+
+          <div className="grid md:grid-cols-3 gap-8">
+            {[
+              {
+                step: "01",
+                title: "Assign Tasks",
+                description: "Create chores, homework, or activities. Set point values. Add photo proof requirement.",
+                icon: Smartphone,
+                color: "#3A7BFA"
+              },
+              {
+                step: "02",
+                title: "Kids Complete",
+                description: "Your child finishes tasks and submits photo proof through the app. No photo, no points.",
+                icon: Camera,
+                color: "#4CCB6E"
+              },
+              {
+                step: "03",
+                title: "Earn & Redeem",
+                description: "Approve completions, points are awarded automatically. Kids redeem for screen time or rewards.",
+                icon: Gift,
+                color: "#FFC300"
+              }
+            ].map((item, index) => (
+              <motion.div
+                key={index}
+                className="bg-white rounded-2xl p-8 shadow-lg"
+                initial={{ opacity: 0, y: 30 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                transition={{ duration: 0.5, delay: index * 0.1 }}
+              >
+                <div className="flex items-center gap-4 mb-4">
+                  <div className="text-4xl font-bold" style={{ color: item.color }}>{item.step}</div>
+                  <div 
+                    className="w-12 h-12 rounded-xl flex items-center justify-center"
+                    style={{ backgroundColor: `${item.color}20` }}
+                  >
+                    <item.icon className="w-6 h-6" style={{ color: item.color }} />
+                  </div>
+                </div>
+                <h3 className="text-xl font-bold mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </motion.div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Features */}
+      <section id="features" className="py-20">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <motion.div 
+            className="text-center mb-16"
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.5 }}
+          >
+            <h2 className="text-3xl sm:text-4xl font-bold text-[#1C1F26] mb-4">Features Parents Love</h2>
+            <p className="text-xl text-gray-600">Everything you need to manage screen time without the daily fights</p>
+          </motion.div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
+            {[
+              {
+                icon: Camera,
+                title: "Photo Proof",
+                description: "Kids must submit photo evidence for every task. No more guessing if they actually did it.",
+                color: "#4CCB6E"
+              },
+              {
+                icon: Lock,
+                title: "Automatic Enforcement",
+                description: "When time runs out, apps lock automatically using iOS Screen Time APIs. No negotiations needed.",
+                color: "#3A7BFA"
+              },
+              {
+                icon: Gift,
+                title: "Flexible Rewards",
+                description: "Screen time, cash, privileges, or experiences. Customize rewards that motivate YOUR child.",
+                color: "#FFC300"
+              },
+              {
+                icon: Clock,
+                title: "Time Banking",
+                description: "Kids can save up points and redeem when they want. Teaches delayed gratification.",
+                color: "#3A7BFA"
+              },
+              {
+                icon: Star,
+                title: "Achievement Badges",
+                description: "Celebrate milestones with visual achievements that keep kids engaged and motivated.",
+                color: "#FFC300"
+              },
+              {
+                icon: Shield,
+                title: "COPPA Compliant",
+                description: "Built with child safety in mind. Your data stays private and secure.",
+                color: "#4CCB6E"
+              }
+            ].map((feature, index) => (
+              <motion.div
+                key={index}
+                className="p-6 rounded-2xl border border-gray-100 hover:shadow-lg transition-shadow"
+                initial={{ opacity: 0, y: 20 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                transition={{ duration: 0.4, delay: index * 0.05 }}
+              >
+                <div 
+                  className="w-12 h-12 rounded-xl flex items-center justify-center mb-4"
+                  style={{ backgroundColor: `${feature.color}15` }}
+                >
+                  <feature.icon className="w-6 h-6" style={{ color: feature.color }} />
+                </div>
+                <h3 className="text-lg font-bold mb-2">{feature.title}</h3>
+                <p className="text-gray-600 text-sm">{feature.description}</p>
+              </motion.div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Social Proof */}
+      <section className="py-20 bg-[#F4F5F7]">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <motion.div 
+            className="text-center mb-12"
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.5 }}
+          >
+            <h2 className="text-3xl sm:text-4xl font-bold text-[#1C1F26] mb-4">What Parents Are Saying</h2>
+          </motion.div>
+
+          <div className="grid md:grid-cols-3 gap-8">
+            {[
+              {
+                quote: "We went from daily tantrums to my son asking what chores he can do. It's been life-changing.",
+                author: "Sarah M.",
+                detail: "Mom of 2, ages 8 & 11"
+              },
+              {
+                quote: "Finally, an app that actually enforces screen time limits. No more 'just 5 more minutes' negotiations.",
+                author: "Michael R.",
+                detail: "Dad of 3, ages 6-14"
+              },
+              {
+                quote: "The photo proof feature is genius. My daughter used to say she cleaned her room. Now I can actually see it.",
+                author: "Jennifer L.",
+                detail: "Mom of 1, age 9"
+              }
+            ].map((testimonial, index) => (
+              <motion.div
+                key={index}
+                className="bg-white p-6 rounded-2xl shadow-lg"
+                initial={{ opacity: 0, y: 20 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                transition={{ duration: 0.4, delay: index * 0.1 }}
+              >
+                <div className="flex space-x-1 mb-4">
+                  {[...Array(5)].map((_, i) => (
+                    <Star key={i} className="w-5 h-5 text-[#FFC300] fill-[#FFC300]" />
+                  ))}
+                </div>
+                <p className="text-gray-700 mb-4 italic">"{testimonial.quote}"</p>
+                <div>
+                  <p className="font-semibold text-[#1C1F26]">{testimonial.author}</p>
+                  <p className="text-sm text-gray-500">{testimonial.detail}</p>
+                </div>
+              </motion.div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Pricing */}
+      <section id="pricing" className="py-20">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <motion.div 
+            className="text-center mb-16"
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.5 }}
+          >
+            <h2 className="text-3xl sm:text-4xl font-bold text-[#1C1F26] mb-4">Simple, Transparent Pricing</h2>
+            <p className="text-xl text-gray-600">Start free. No credit card required.</p>
+          </motion.div>
+
+          <div className="max-w-md mx-auto">
+            <motion.div 
+              className="bg-white rounded-2xl shadow-2xl border-2 border-[#3A7BFA] p-8 relative overflow-hidden"
+              initial={{ opacity: 0, scale: 0.95 }}
+              whileInView={{ opacity: 1, scale: 1 }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.5 }}
+            >
+              <div className="absolute top-0 right-0 bg-[#FFC300] text-[#1C1F26] text-sm font-bold px-4 py-1 rounded-bl-xl">
+                MOST POPULAR
+              </div>
+              
+              <h3 className="text-2xl font-bold mb-2">Family Plan</h3>
+              <p className="text-gray-600 mb-6">Everything you need for your family</p>
+              
+              <div className="mb-6">
+                <span className="text-5xl font-bold">$9.99</span>
+                <span className="text-gray-600">/month</span>
+                <p className="text-sm text-gray-500 mt-1">or $99/year (save 17%)</p>
+              </div>
+
+              <div className="space-y-3 mb-8">
+                {[
+                  "7-day free trial",
+                  "Unlimited children",
+                  "Unlimited tasks",
+                  "Photo proof verification",
+                  "Automatic screen time enforcement",
+                  "All reward types (time, cash, privileges)",
+                  "Progress tracking & analytics",
+                  "Priority support"
+                ].map((feature, i) => (
+                  <div key={i} className="flex items-center space-x-3">
+                    <CheckCircle className="w-5 h-5 text-[#4CCB6E] flex-shrink-0" />
+                    <span className="text-gray-700">{feature}</span>
+                  </div>
+                ))}
+              </div>
+
+              <motion.a 
+                href="/download"
+                className="block w-full py-4 bg-[#3A7BFA] text-white font-semibold rounded-xl text-lg hover:bg-blue-600 transition-colors text-center"
+                whileHover={{ scale: 1.02 }}
+                whileTap={{ scale: 0.98 }}
+              >
+                Start Free Trial
+              </motion.a>
+              
+              <p className="text-center text-sm text-gray-500 mt-4">
+                Cancel anytime. No questions asked.
+              </p>
+            </motion.div>
+          </div>
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <section id="faq" className="py-20 bg-[#F4F5F7]">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+          <motion.div 
+            className="text-center mb-12"
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.5 }}
+          >
+            <h2 className="text-3xl sm:text-4xl font-bold text-[#1C1F26] mb-4">Frequently Asked Questions</h2>
+          </motion.div>
+
+          <div className="space-y-4">
+            {[
+              {
+                q: "How does the screen time enforcement work?",
+                a: "Screen Time Hero uses Apple's native Screen Time APIs (FamilyControls framework) to actually block apps when your child's time runs out. This is real enforcement, not just tracking. The restrictions are applied at the system level."
+              },
+              {
+                q: "What devices does this work on?",
+                a: "Currently, Screen Time Hero works on iPhone and iPad running iOS 15.0 or later. For full screen time enforcement features, iOS 16.0+ is required. We're actively working on an Android version."
+              },
+              {
+                q: "Can my child just uninstall the app?",
+                a: "On iOS, you can prevent app deletion through Screen Time settings (Settings > Screen Time > Content & Privacy Restrictions > iTunes & App Store Purchases > Deleting Apps > Don't Allow). We provide step-by-step instructions for this during setup."
+              },
+              {
+                q: "What if my child doesn't have their own device?",
+                a: "Screen Time Hero works best when children have their own iOS device. However, you can also use it on a shared device by setting up different user profiles or using the app's child mode with a PIN."
+              },
+              {
+                q: "Is my data secure?",
+                a: "Absolutely. We use industry-standard encryption (TLS 1.2+ in transit, AES-256 at rest). We're COPPA compliant and never sell your data. Photos are stored securely and only accessible to you and your linked family members."
+              },
+              {
+                q: "Can I use this for multiple children?",
+                a: "Yes! The Family Plan includes unlimited children at no extra cost. Each child has their own profile, tasks, and reward balance."
+              },
+              {
+                q: "What makes this different from other chore apps?",
+                a: "Two key differences: (1) We're the only app that uses screen time itself as a reward — others use points or money only. (2) We actually enforce screen time limits automatically using iOS native controls, not just track usage."
+              },
+              {
+                q: "Can I cancel my subscription?",
+                a: "Yes, you can cancel anytime from your account settings. If you cancel, you'll continue to have access until the end of your billing period. We also offer a 7-day free trial with no credit card required."
+              }
+            ].map((faq, index) => (
+              <motion.div
+                key={index}
+                className="bg-white rounded-xl overflow-hidden"
+                initial={{ opacity: 0, y: 20 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                transition={{ duration: 0.3, delay: index * 0.05 }}
+              >
+                <button
+                  className="w-full px-6 py-4 text-left flex items-center justify-between hover:bg-gray-50 transition-colors"
+                  onClick={() => setOpenFaq(openFaq === index ? null : index)}
+                >
+                  <span className="font-semibold text-[#1C1F26]">{faq.q}</span>
+                  <ChevronDown 
+                    className={`w-5 h-5 text-gray-400 transition-transform ${openFaq === index ? 'rotate-180' : ''}`} 
+                  />
+                </button>
+                {openFaq === index && (
+                  <div className="px-6 pb-4 text-gray-600">
+                    {faq.a}
+                  </div>
+                )}
+              </motion.div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA Section */}
+      <section className="py-20">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <motion.div 
+            className="bg-gradient-to-br from-[#3A7BFA] to-[#2563EB] rounded-3xl p-8 md:p-16 text-center text-white"
+            initial={{ opacity: 0, y: 30 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.5 }}
+          >
+            <h2 className="text-3xl sm:text-4xl font-bold mb-4">Ready to End the Screen Time Fights?</h2>
+            <p className="text-xl text-blue-100 mb-8 max-w-2xl mx-auto">
+              Join thousands of families who've transformed screen time from a battle into motivation.
+            </p>
+            <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+              <motion.a 
+                href="/download"
+                className="w-full sm:w-auto px-8 py-4 bg-[#FFC300] text-[#1C1F26] font-semibold rounded-xl text-lg hover:bg-yellow-400 transition-colors text-center"
+                whileHover={{ scale: 1.02 }}
+                whileTap={{ scale: 0.98 }}
+              >
+                Start Your Free 7-Day Trial
+              </motion.a>
+            </div>
+            <p className="mt-4 text-sm text-blue-200">No credit card required. Cancel anytime.</p>
+          </motion.div>
+        </div>
+      </section>
+
+      {/* Footer */}
+      <footer className="bg-[#1C1F26] text-white py-12">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="grid md:grid-cols-4 gap-8 mb-8">
+            <div>
+              <div className="flex items-center space-x-2 mb-4">
+                <Image src="/logo.svg" alt="Screen Time Hero" width={32} height={32} />
+                <span className="text-xl font-bold">Screen Time Hero</span>
+              </div>
+              <p className="text-gray-400 text-sm">
+                Transforming screen time battles into motivation, one family at a time.
+              </p>
+            </div>
+            <div>
+              <h4 className="font-semibold mb-4">Product</h4>
+              <ul className="space-y-2 text-sm text-gray-400">
+                <li><button onClick={() => scrollToSection("features")} className="hover:text-white transition-colors">Features</button></li>
+                <li><button onClick={() => scrollToSection("pricing")} className="hover:text-white transition-colors">Pricing</button></li>
+                <li><button onClick={() => scrollToSection("faq")} className="hover:text-white transition-colors">FAQ</button></li>
+              </ul>
+            </div>
+            <div>
+              <h4 className="font-semibold mb-4">Company</h4>
+              <ul className="space-y-2 text-sm text-gray-400">
+                <li><Link href="/download" className="hover:text-white transition-colors">Download</Link></li>
+                <li><a href="mailto:support@screentimehero.com" className="hover:text-white transition-colors">Contact</a></li>
+              </ul>
+            </div>
+            <div>
+              <h4 className="font-semibold mb-4">Legal</h4>
+              <ul className="space-y-2 text-sm text-gray-400">
+                <li><Link href="/privacy" className="hover:text-white transition-colors">Privacy Policy</Link></li>
+                <li><Link href="/terms" className="hover:text-white transition-colors">Terms of Service</Link></li>
+              </ul>
+            </div>
+          </div>
+          <div className="border-t border-gray-800 pt-8 text-center text-sm text-gray-400">
+            <p>&copy; 2026 Screen Time Hero. All rights reserved. Made with 💙 for families everywhere.</p>
+          </div>
+        </div>
+      </footer>
     </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -61,12 +61,12 @@ export default function Home() {
             </div>
 
             <div className="hidden md:flex items-center space-x-4">
-              <a
+              <Link
                 href="/download"
                 className="px-4 py-2 bg-[#3A7BFA] text-white font-medium rounded-lg hover:bg-blue-600 transition-colors"
               >
                 Start Free Trial
-              </a>
+              </Link>
             </div>
 
             <button
@@ -90,7 +90,7 @@ export default function Home() {
               <button onClick={() => scrollToSection("pricing")} className="block w-full text-left py-2 text-gray-600">Pricing</button>
               <button onClick={() => scrollToSection("faq")} className="block w-full text-left py-2 text-gray-600">FAQ</button>
               <div className="pt-3 border-t border-gray-100">
-                <a href="/download" className="block w-full py-2 bg-[#3A7BFA] text-white font-medium rounded-lg text-center">Start Free Trial</a>
+                <Link href="/download" className="block w-full py-2 bg-[#3A7BFA] text-white font-medium rounded-lg text-center">Start Free Trial</Link>
               </div>
             </div>
           </div>
@@ -123,14 +123,18 @@ export default function Home() {
             </p>
 
             <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
-              <motion.a 
-                href="/download"
-                className="w-full sm:w-auto px-8 py-4 bg-[#3A7BFA] text-white font-semibold rounded-xl text-lg hover:bg-blue-600 transition-colors shadow-lg shadow-blue-500/25 text-center"
+              <motion.div
+                className="w-full sm:w-auto"
                 whileHover={{ scale: 1.02 }}
                 whileTap={{ scale: 0.98 }}
               >
-                Start Your Free Trial
-              </motion.a>
+                <Link
+                  href="/download"
+                  className="block w-full sm:w-auto px-8 py-4 bg-[#3A7BFA] text-white font-semibold rounded-xl text-lg hover:bg-blue-600 transition-colors shadow-lg shadow-blue-500/25 text-center"
+                >
+                  Start Your Free Trial
+                </Link>
+              </motion.div>
               <motion.button 
                 className="w-full sm:w-auto px-8 py-4 bg-white text-[#1C1F26] font-semibold rounded-xl text-lg border-2 border-gray-200 hover:border-[#3A7BFA] hover:text-[#3A7BFA] transition-colors"
                 whileHover={{ scale: 1.02 }}
@@ -468,14 +472,17 @@ export default function Home() {
                 ))}
               </div>
 
-              <motion.a 
-                href="/download"
-                className="block w-full py-4 bg-[#3A7BFA] text-white font-semibold rounded-xl text-lg hover:bg-blue-600 transition-colors text-center"
+              <motion.div
                 whileHover={{ scale: 1.02 }}
                 whileTap={{ scale: 0.98 }}
               >
-                Start Free Trial
-              </motion.a>
+                <Link
+                  href="/download"
+                  className="block w-full py-4 bg-[#3A7BFA] text-white font-semibold rounded-xl text-lg hover:bg-blue-600 transition-colors text-center"
+                >
+                  Start Free Trial
+                </Link>
+              </motion.div>
               
               <p className="text-center text-sm text-gray-500 mt-4">
                 Cancel anytime. No questions asked.
@@ -584,14 +591,18 @@ export default function Home() {
               Join thousands of families who&apos;ve transformed screen time from a battle into motivation.
             </p>
             <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
-              <motion.a 
-                href="/download"
-                className="w-full sm:w-auto px-8 py-4 bg-[#FFC300] text-[#1C1F26] font-semibold rounded-xl text-lg hover:bg-yellow-400 transition-colors text-center"
+              <motion.div
+                className="w-full sm:w-auto"
                 whileHover={{ scale: 1.02 }}
                 whileTap={{ scale: 0.98 }}
               >
-                Start Your Free 7-Day Trial
-              </motion.a>
+                <Link
+                  href="/download"
+                  className="block w-full sm:w-auto px-8 py-4 bg-[#FFC300] text-[#1C1F26] font-semibold rounded-xl text-lg hover:bg-yellow-400 transition-colors text-center"
+                >
+                  Start Your Free 7-Day Trial
+                </Link>
+              </motion.div>
             </div>
             <p className="mt-4 text-sm text-blue-200">No credit card required. Cancel anytime.</p>
           </motion.div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -37,8 +37,13 @@ export default function Home() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [openFaq, setOpenFaq] = useState<number | null>(null);
 
+  const NAV_HEIGHT = 64;
   const scrollToSection = (id: string) => {
-    document.getElementById(id)?.scrollIntoView({ behavior: "smooth" });
+    const section = document.getElementById(id);
+    if (section) {
+      const top = section.getBoundingClientRect().top + window.scrollY - NAV_HEIGHT;
+      window.scrollTo({ top, behavior: "smooth" });
+    }
     setMobileMenuOpen(false);
   };
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -177,12 +177,12 @@ export default function Home() {
                           <span className="text-sm font-medium">{task}</span>
                         </div>
                         <div className="flex space-x-2">
-                          <button className="p-2 bg-[#4CCB6E] text-white rounded-lg">
+                          <div aria-hidden="true" className="p-2 bg-[#4CCB6E] text-white rounded-lg">
                             <CheckCircle className="w-4 h-4" />
-                          </button>
-                          <button className="p-2 bg-gray-200 text-gray-600 rounded-lg">
+                          </div>
+                          <div aria-hidden="true" className="p-2 bg-gray-200 text-gray-600 rounded-lg">
                             <X className="w-4 h-4" />
-                          </button>
+                          </div>
                         </div>
                       </div>
                     ))}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -33,6 +33,122 @@ const staggerContainer = {
   }
 };
 
+const HOW_IT_WORKS_STEPS = [
+  {
+    step: "01",
+    title: "Assign Tasks",
+    description: "Create chores, homework, or activities. Set point values. Add photo proof requirement.",
+    icon: Smartphone,
+    color: "#3A7BFA"
+  },
+  {
+    step: "02",
+    title: "Kids Complete",
+    description: "Your child finishes tasks and submits photo proof through the app. No photo, no points.",
+    icon: Camera,
+    color: "#4CCB6E"
+  },
+  {
+    step: "03",
+    title: "Earn & Redeem",
+    description: "Approve completions, points are awarded automatically. Kids redeem for screen time or rewards.",
+    icon: Gift,
+    color: "#FFC300"
+  }
+];
+
+const FEATURES = [
+  {
+    icon: Camera,
+    title: "Photo Proof",
+    description: "Kids must submit photo evidence for every task. No more guessing if they actually did it.",
+    color: "#4CCB6E"
+  },
+  {
+    icon: Lock,
+    title: "Automatic Enforcement",
+    description: "When time runs out, apps lock automatically using iOS Screen Time APIs. No negotiations needed.",
+    color: "#3A7BFA"
+  },
+  {
+    icon: Gift,
+    title: "Flexible Rewards",
+    description: "Screen time, cash, privileges, or experiences. Customize rewards that motivate YOUR child.",
+    color: "#FFC300"
+  },
+  {
+    icon: Clock,
+    title: "Time Banking",
+    description: "Kids can save up points and redeem when they want. Teaches delayed gratification.",
+    color: "#3A7BFA"
+  },
+  {
+    icon: Star,
+    title: "Achievement Badges",
+    description: "Celebrate milestones with visual achievements that keep kids engaged and motivated.",
+    color: "#FFC300"
+  },
+  {
+    icon: Shield,
+    title: "COPPA Compliant",
+    description: "Built with child safety in mind. Your data stays private and secure.",
+    color: "#4CCB6E"
+  }
+];
+
+const TESTIMONIALS = [
+  {
+    quote: "We went from daily tantrums to my son asking what chores he can do. It's been life-changing.",
+    author: "Sarah M.",
+    detail: "Mom of 2, ages 8 & 11"
+  },
+  {
+    quote: "Finally, an app that actually enforces screen time limits. No more 'just 5 more minutes' negotiations.",
+    author: "Michael R.",
+    detail: "Dad of 3, ages 6-14"
+  },
+  {
+    quote: "The photo proof feature is genius. My daughter used to say she cleaned her room. Now I can actually see it.",
+    author: "Jennifer L.",
+    detail: "Mom of 1, age 9"
+  }
+];
+
+const FAQS = [
+  {
+    q: "How does the screen time enforcement work?",
+    a: "Screen Time Hero uses Apple's native Screen Time APIs (FamilyControls framework) to actually block apps when your child's time runs out. This is real enforcement, not just tracking. The restrictions are applied at the system level."
+  },
+  {
+    q: "What devices does this work on?",
+    a: "Currently, Screen Time Hero works on iPhone and iPad running iOS 15.0 or later. For full screen time enforcement features, iOS 16.0+ is required. We're actively working on an Android version."
+  },
+  {
+    q: "Can my child just uninstall the app?",
+    a: "On iOS, you can prevent app deletion through Screen Time settings (Settings > Screen Time > Content & Privacy Restrictions > iTunes & App Store Purchases > Deleting Apps > Don't Allow). We provide step-by-step instructions for this during setup."
+  },
+  {
+    q: "What if my child doesn't have their own device?",
+    a: "Screen Time Hero works best when children have their own iOS device. However, you can also use it on a shared device by setting up different user profiles or using the app's child mode with a PIN."
+  },
+  {
+    q: "Is my data secure?",
+    a: "Absolutely. We use industry-standard encryption (TLS 1.2+ in transit, AES-256 at rest). We're COPPA compliant and never sell your data. Photos are stored securely and only accessible to you and your linked family members."
+  },
+  {
+    q: "Can I use this for multiple children?",
+    a: "Yes! The Family Plan includes unlimited children at no extra cost. Each child has their own profile, tasks, and reward balance."
+  },
+  {
+    q: "What makes this different from other chore apps?",
+    a: "Two key differences: (1) We're the only app that uses screen time itself as a reward — others use points or money only. (2) We actually enforce screen time limits automatically using iOS native controls, not just track usage."
+  },
+  {
+    q: "Can I cancel my subscription?",
+    a: "Yes, you can cancel anytime from your account settings. If you cancel, you'll continue to have access until the end of your billing period. We also offer a 7-day free trial with no credit card required."
+  }
+];
+
 export default function Home() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [openFaq, setOpenFaq] = useState<number | null>(null);
@@ -246,29 +362,7 @@ export default function Home() {
           </motion.div>
 
           <div className="grid md:grid-cols-3 gap-8">
-            {[
-              {
-                step: "01",
-                title: "Assign Tasks",
-                description: "Create chores, homework, or activities. Set point values. Add photo proof requirement.",
-                icon: Smartphone,
-                color: "#3A7BFA"
-              },
-              {
-                step: "02",
-                title: "Kids Complete",
-                description: "Your child finishes tasks and submits photo proof through the app. No photo, no points.",
-                icon: Camera,
-                color: "#4CCB6E"
-              },
-              {
-                step: "03",
-                title: "Earn & Redeem",
-                description: "Approve completions, points are awarded automatically. Kids redeem for screen time or rewards.",
-                icon: Gift,
-                color: "#FFC300"
-              }
-            ].map((item, index) => (
+            {HOW_IT_WORKS_STEPS.map((item, index) => (
               <motion.div
                 key={index}
                 className="bg-white rounded-2xl p-8 shadow-lg"
@@ -309,44 +403,7 @@ export default function Home() {
           </motion.div>
 
           <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-            {[
-              {
-                icon: Camera,
-                title: "Photo Proof",
-                description: "Kids must submit photo evidence for every task. No more guessing if they actually did it.",
-                color: "#4CCB6E"
-              },
-              {
-                icon: Lock,
-                title: "Automatic Enforcement",
-                description: "When time runs out, apps lock automatically using iOS Screen Time APIs. No negotiations needed.",
-                color: "#3A7BFA"
-              },
-              {
-                icon: Gift,
-                title: "Flexible Rewards",
-                description: "Screen time, cash, privileges, or experiences. Customize rewards that motivate YOUR child.",
-                color: "#FFC300"
-              },
-              {
-                icon: Clock,
-                title: "Time Banking",
-                description: "Kids can save up points and redeem when they want. Teaches delayed gratification.",
-                color: "#3A7BFA"
-              },
-              {
-                icon: Star,
-                title: "Achievement Badges",
-                description: "Celebrate milestones with visual achievements that keep kids engaged and motivated.",
-                color: "#FFC300"
-              },
-              {
-                icon: Shield,
-                title: "COPPA Compliant",
-                description: "Built with child safety in mind. Your data stays private and secure.",
-                color: "#4CCB6E"
-              }
-            ].map((feature, index) => (
+            {FEATURES.map((feature, index) => (
               <motion.div
                 key={index}
                 className="p-6 rounded-2xl border border-gray-100 hover:shadow-lg transition-shadow"
@@ -383,23 +440,7 @@ export default function Home() {
           </motion.div>
 
           <div className="grid md:grid-cols-3 gap-8">
-            {[
-              {
-                quote: "We went from daily tantrums to my son asking what chores he can do. It's been life-changing.",
-                author: "Sarah M.",
-                detail: "Mom of 2, ages 8 & 11"
-              },
-              {
-                quote: "Finally, an app that actually enforces screen time limits. No more 'just 5 more minutes' negotiations.",
-                author: "Michael R.",
-                detail: "Dad of 3, ages 6-14"
-              },
-              {
-                quote: "The photo proof feature is genius. My daughter used to say she cleaned her room. Now I can actually see it.",
-                author: "Jennifer L.",
-                detail: "Mom of 1, age 9"
-              }
-            ].map((testimonial, index) => (
+            {TESTIMONIALS.map((testimonial, index) => (
               <motion.div
                 key={index}
                 className="bg-white p-6 rounded-2xl shadow-lg"
@@ -511,40 +552,7 @@ export default function Home() {
           </motion.div>
 
           <div className="space-y-4">
-            {[
-              {
-                q: "How does the screen time enforcement work?",
-                a: "Screen Time Hero uses Apple's native Screen Time APIs (FamilyControls framework) to actually block apps when your child's time runs out. This is real enforcement, not just tracking. The restrictions are applied at the system level."
-              },
-              {
-                q: "What devices does this work on?",
-                a: "Currently, Screen Time Hero works on iPhone and iPad running iOS 15.0 or later. For full screen time enforcement features, iOS 16.0+ is required. We're actively working on an Android version."
-              },
-              {
-                q: "Can my child just uninstall the app?",
-                a: "On iOS, you can prevent app deletion through Screen Time settings (Settings > Screen Time > Content & Privacy Restrictions > iTunes & App Store Purchases > Deleting Apps > Don't Allow). We provide step-by-step instructions for this during setup."
-              },
-              {
-                q: "What if my child doesn't have their own device?",
-                a: "Screen Time Hero works best when children have their own iOS device. However, you can also use it on a shared device by setting up different user profiles or using the app's child mode with a PIN."
-              },
-              {
-                q: "Is my data secure?",
-                a: "Absolutely. We use industry-standard encryption (TLS 1.2+ in transit, AES-256 at rest). We're COPPA compliant and never sell your data. Photos are stored securely and only accessible to you and your linked family members."
-              },
-              {
-                q: "Can I use this for multiple children?",
-                a: "Yes! The Family Plan includes unlimited children at no extra cost. Each child has their own profile, tasks, and reward balance."
-              },
-              {
-                q: "What makes this different from other chore apps?",
-                a: "Two key differences: (1) We're the only app that uses screen time itself as a reward — others use points or money only. (2) We actually enforce screen time limits automatically using iOS native controls, not just track usage."
-              },
-              {
-                q: "Can I cancel my subscription?",
-                a: "Yes, you can cancel anytime from your account settings. If you cancel, you'll continue to have access until the end of your billing period. We also offer a 7-day free trial with no credit card required."
-              }
-            ].map((faq, index) => (
+            {FAQS.map((faq, index) => (
               <motion.div
                 key={index}
                 className="bg-white rounded-xl overflow-hidden"

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,7 @@ const eslintConfig = defineConfig([
     ".next/**",
     "out/**",
     "build/**",
+    "dist/**",
     "next-env.d.ts",
   ]),
 ]);


### PR DESCRIPTION
## Summary
- Restores the original marketing landing page that was replaced with a coming-soon placeholder in 63c4807, so the full site (with nav links to `/privacy`, `/terms`, and `/download`) is accessible again.
- Vercel Analytics and Speed Insights instrumentation added in ac8e42e is preserved in `app/layout.tsx` — this PR does not touch layout.
- Escaped a handful of JSX quote entities in `app/page.tsx` and the pre-existing `app/download/page.tsx` so the pre-push QA lint gate passes.
- Added `dist/**` (Next.js static-export output directory) to `eslint.config.mjs` global ignores so tracked build artifacts don't pollute lint.

## Test plan
- [x] `npm run build` succeeds; routes prerendered: `/`, `/download`, `/privacy`, `/terms`
- [x] `npm run lint` → 0 errors
- [x] `/privacy`, `/terms`, `/download` pages untouched and still present
- [ ] Manual: confirm Vercel preview renders hero, features, testimonials, and CTAs correctly
- [ ] Manual: click-through to `/privacy`, `/terms`, `/download` from the restored homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Launched a full marketing homepage replacing the placeholder, with Hero, How It Works, Features, Social Proof, Pricing, FAQ, CTA and Footer sections.
  * Added responsive mobile navigation, smooth in-page scrolling, entrance/hover animations, and an interactive FAQ accordion.

* **Style**
  * Standardized apostrophe encoding for consistent display across the download content.

* **Chores**
  * Extended linting ignore patterns to include additional build artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->