### PR TITLE
feat: add Screen Time Hero support page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -58,6 +58,7 @@ export default function Home() {
               <button onClick={() => scrollToSection("features")} className="text-gray-600 hover:text-[#3A7BFA] transition-colors">Features</button>
               <button onClick={() => scrollToSection("pricing")} className="text-gray-600 hover:text-[#3A7BFA] transition-colors">Pricing</button>
               <button onClick={() => scrollToSection("faq")} className="text-gray-600 hover:text-[#3A7BFA] transition-colors">FAQ</button>
+              <Link href="/support" className="text-gray-600 hover:text-[#3A7BFA] transition-colors">Support</Link>
             </div>
 
             <div className="hidden md:flex items-center space-x-4">
@@ -89,6 +90,7 @@ export default function Home() {
               <button onClick={() => scrollToSection("features")} className="block w-full text-left py-2 text-gray-600">Features</button>
               <button onClick={() => scrollToSection("pricing")} className="block w-full text-left py-2 text-gray-600">Pricing</button>
               <button onClick={() => scrollToSection("faq")} className="block w-full text-left py-2 text-gray-600">FAQ</button>
+              <Link href="/support" className="block w-full text-left py-2 text-gray-600">Support</Link>
               <div className="pt-3 border-t border-gray-100 space-y-2">
                 <button className="w-full py-2 text-[#3A7BFA] font-medium">Sign In</button>
                 <a href="/download" className="block w-full py-2 bg-[#3A7BFA] text-white font-medium rounded-lg text-center">Start Free Trial</a>
@@ -616,6 +618,7 @@ export default function Home() {
               <h4 className="font-semibold mb-4">Company</h4>
               <ul className="space-y-2 text-sm text-gray-400">
                 <li><Link href="/download" className="hover:text-white transition-colors">Download</Link></li>
+                <li><Link href="/support" className="hover:text-white transition-colors">Support</Link></li>
                 <li><a href="mailto:support@screentimehero.com" className="hover:text-white transition-colors">Contact</a></li>
               </ul>
             </div>
@@ -624,6 +627,7 @@ export default function Home() {
               <ul className="space-y-2 text-sm text-gray-400">
                 <li><Link href="/privacy" className="hover:text-white transition-colors">Privacy Policy</Link></li>
                 <li><Link href="/terms" className="hover:text-white transition-colors">Terms of Service</Link></li>
+                <li><Link href="/support" className="hover:text-white transition-colors">Support</Link></li>
               </ul>
             </div>
           </div>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -167,6 +167,7 @@ export default function PrivacyPage() {
               <Link href="/download" className="hover:text-white transition-colors">Download</Link>
               <Link href="/privacy" className="hover:text-white transition-colors">Privacy</Link>
               <Link href="/terms" className="hover:text-white transition-colors">Terms</Link>
+              <Link href="/support" className="hover:text-white transition-colors">Support</Link>
             </nav>
           </div>
           <div className="mt-6 pt-6 border-t border-gray-800 flex flex-col sm:flex-row items-center justify-between gap-2 text-sm text-gray-400">

--- a/app/support/page.tsx
+++ b/app/support/page.tsx
@@ -8,6 +8,9 @@ export const metadata: Metadata = {
   description: "Get help with Screen Time Hero setup, subscriptions, Family Sharing, account access, and data requests.",
 };
 
+const SUPPORT_EMAIL = "support@screentimehero.com";
+const SUPPORT_MAILTO = `mailto:${SUPPORT_EMAIL}`;
+
 const faqs = [
   {
     id: "how-it-works",
@@ -25,13 +28,13 @@ const faqs = [
     id: "restore-subscription",
     question: "Can I restore my subscription?",
     answer:
-      "Yes. Open the app, go to Settings, and use Restore Purchases. If that does not work, email support@screentimehero.com and include the Apple ID used for purchase.",
+      `Yes. Open the app, go to Settings, and use Restore Purchases. If that does not work, email ${SUPPORT_EMAIL} and include the Apple ID used for purchase.`,
   },
   {
     id: "delete-data",
     question: "How do I delete my family's data?",
     answer:
-      "Email support@screentimehero.com from the parent account email and request account deletion. We will process the request and remove associated family data.",
+      `Email ${SUPPORT_EMAIL} from the parent account email and request account deletion. We will process the request and remove associated family data.`,
   },
 ];
 
@@ -63,10 +66,10 @@ export default function SupportPage() {
               For help with account access, billing, Family Sharing setup, or app questions, email us anytime.
             </p>
             <a
-              href="mailto:support@screentimehero.com"
+              href={SUPPORT_MAILTO}
               className="inline-flex items-center rounded-xl bg-[#3A7BFA] px-5 py-3 font-semibold text-white hover:bg-blue-600 transition-colors"
             >
-              support@screentimehero.com
+              {SUPPORT_EMAIL}
             </a>
             <p className="text-sm text-gray-500 mt-4">
               Please include your device type, iOS version, and a short description of the issue so we can help faster.
@@ -105,7 +108,7 @@ export default function SupportPage() {
           <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">Account and Billing Requests</h2>
           <div className="space-y-3 text-gray-600 leading-relaxed">
             <p>
-              For subscription questions, restoration issues, refunds, or account deletion requests, email <a href="mailto:support@screentimehero.com" className="text-[#3A7BFA] hover:underline">support@screentimehero.com</a> from your parent account email.
+              For subscription questions, restoration issues, refunds, or account deletion requests, email <a href={SUPPORT_MAILTO} className="text-[#3A7BFA] hover:underline">{SUPPORT_EMAIL}</a> from your parent account email.
             </p>
             <p>
               We may ask follow-up questions to verify account ownership before making account-level changes.

--- a/app/support/page.tsx
+++ b/app/support/page.tsx
@@ -1,0 +1,137 @@
+import Link from "next/link";
+import Image from "next/image";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Support - Screen Time Hero",
+  description: "Get help with Screen Time Hero setup, subscriptions, Family Sharing, account access, and data requests.",
+};
+
+const faqs = [
+  {
+    question: "How does Screen Time Hero work?",
+    answer:
+      "Parents assign tasks, kids submit photo proof, and approved tasks earn points that can be redeemed for screen time or other rewards.",
+  },
+  {
+    question: "Do I need Apple Family Sharing?",
+    answer:
+      "Yes, Apple Family Sharing is recommended for the full screen time management experience. It helps Screen Time Hero access the child device controls required by Apple's FamilyControls framework.",
+  },
+  {
+    question: "Can I restore my subscription?",
+    answer:
+      "Yes. Open the app, go to Settings, and use Restore Purchases. If that does not work, email support@screentimehero.com and include the Apple ID used for purchase.",
+  },
+  {
+    question: "How do I delete my family's data?",
+    answer:
+      "Email support@screentimehero.com from the parent account email and request account deletion. We will process the request and remove associated family data.",
+  },
+];
+
+export default function SupportPage() {
+  return (
+    <div className="min-h-screen bg-white">
+      <header className="border-b border-gray-100">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex items-center justify-between">
+          <Link href="/" className="flex items-center space-x-2">
+            <Image src="/logo.svg" alt="Screen Time Hero" width={32} height={32} />
+            <span className="text-xl font-bold text-[#1C1F26]">Screen Time Hero</span>
+          </Link>
+          <Link href="/" className="text-sm text-[#3A7BFA] hover:underline">Back to Home</Link>
+        </div>
+      </header>
+
+      <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <div className="mb-10">
+          <h1 className="text-4xl font-bold text-[#1C1F26] mb-3">Support</h1>
+          <p className="text-lg text-gray-600 max-w-2xl">
+            Need help with setup, Family Sharing, subscriptions, or your account? We&apos;re here to help.
+          </p>
+        </div>
+
+        <div className="grid gap-6 md:grid-cols-2 mb-12">
+          <section className="rounded-2xl border border-gray-200 p-6 bg-gray-50">
+            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">Contact Support</h2>
+            <p className="text-gray-600 mb-4">
+              For help with account access, billing, Family Sharing setup, or app questions, email us anytime.
+            </p>
+            <a
+              href="mailto:support@screentimehero.com"
+              className="inline-flex items-center rounded-xl bg-[#3A7BFA] px-5 py-3 font-semibold text-white hover:bg-blue-600 transition-colors"
+            >
+              support@screentimehero.com
+            </a>
+            <p className="text-sm text-gray-500 mt-4">
+              Please include your device type, iOS version, and a short description of the issue so we can help faster.
+            </p>
+          </section>
+
+          <section className="rounded-2xl border border-gray-200 p-6">
+            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">Helpful Links</h2>
+            <ul className="space-y-3 text-gray-600">
+              <li>
+                <Link href="/download" className="text-[#3A7BFA] hover:underline">Download the app</Link>
+              </li>
+              <li>
+                <Link href="/privacy" className="text-[#3A7BFA] hover:underline">Privacy Policy</Link>
+              </li>
+              <li>
+                <Link href="/terms" className="text-[#3A7BFA] hover:underline">Terms of Service</Link>
+              </li>
+            </ul>
+          </section>
+        </div>
+
+        <section className="mb-12">
+          <h2 className="text-2xl font-bold text-[#1C1F26] mb-6">Frequently Asked Questions</h2>
+          <div className="space-y-4">
+            {faqs.map((faq) => (
+              <div key={faq.question} className="rounded-2xl border border-gray-200 p-6">
+                <h3 className="text-lg font-semibold text-[#1C1F26] mb-2">{faq.question}</h3>
+                <p className="text-gray-600 leading-relaxed">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="rounded-3xl bg-[#F4F5F7] p-8">
+          <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">Account and Billing Requests</h2>
+          <div className="space-y-3 text-gray-600 leading-relaxed">
+            <p>
+              For subscription questions, restoration issues, refunds, or account deletion requests, email <a href="mailto:support@screentimehero.com" className="text-[#3A7BFA] hover:underline">support@screentimehero.com</a> from your parent account email.
+            </p>
+            <p>
+              We may ask follow-up questions to verify account ownership before making account-level changes.
+            </p>
+          </div>
+        </section>
+      </main>
+
+      <footer className="bg-[#1C1F26] text-white py-8 mt-12">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
+            <div className="flex items-center space-x-2">
+              <Image src="/logo.svg" alt="Screen Time Hero" width={24} height={24} />
+              <span className="font-bold">Screen Time Hero</span>
+            </div>
+            <nav className="flex items-center space-x-6 text-sm text-gray-400">
+              <Link href="/" className="hover:text-white transition-colors">Home</Link>
+              <Link href="/download" className="hover:text-white transition-colors">Download</Link>
+              <Link href="/privacy" className="hover:text-white transition-colors">Privacy</Link>
+              <Link href="/terms" className="hover:text-white transition-colors">Terms</Link>
+              <Link href="/support" className="hover:text-white transition-colors">Support</Link>
+            </nav>
+          </div>
+          <div className="mt-6 pt-6 border-t border-gray-800 flex flex-col sm:flex-row items-center justify-between gap-2 text-sm text-gray-400">
+            <p>&copy; 2026 Screen Time Hero. All rights reserved.</p>
+            <a href="mailto:support@screentimehero.com" className="hover:text-white transition-colors">
+              support@screentimehero.com
+            </a>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -160,6 +160,7 @@ export default function TermsPage() {
               <Link href="/download" className="hover:text-white transition-colors">Download</Link>
               <Link href="/privacy" className="hover:text-white transition-colors">Privacy</Link>
               <Link href="/terms" className="hover:text-white transition-colors">Terms</Link>
+              <Link href="/support" className="hover:text-white transition-colors">Support</Link>
             </nav>
           </div>
           <div className="mt-6 pt-6 border-t border-gray-800 flex flex-col sm:flex-row items-center justify-between gap-2 text-sm text-gray-400">


### PR DESCRIPTION
## Summary
- add a public /support page for Screen Time Hero
- add support links to the landing page and legal pages
- provide a stable support destination for App Store metadata

## Validation
- npm run lint
- npm run build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Launched a Support page with FAQs, contact (mailto) CTAs, account/billing guidance, and quick links to key resources.
  * Added Support links in the header, mobile menu, and footer for easier sitewide access.

* **Refactor**
  * Consolidated footer markup into a shared SiteFooter component and applied it across pages for consistent footer content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->