### PR TITLE
chore: update pricing to $6.99/mo and $69.99/year

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -497,9 +497,9 @@ export default function Home() {
               <p className="text-gray-600 mb-6">Everything you need for your family</p>
               
               <div className="mb-6">
-                <span className="text-5xl font-bold">$9.99</span>
+                <span className="text-5xl font-bold">$6.99</span>
                 <span className="text-gray-600">/month</span>
-                <p className="text-sm text-gray-500 mt-1">or $99/year (save 17%)</p>
+                <p className="text-sm text-gray-500 mt-1">or $69.99/year (save 17%)</p>
               </div>
 
               <div className="space-y-3 mb-8">


### PR DESCRIPTION
Updates pricing on landing page from $9.99/month to $6.99/month and $99/year to $69.99/year based on competitive analysis of 10 competitors in the parental control and chore/reward space.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Family Plan pricing: monthly plan is now $6.99 (previously $9.99) and annual plan is now $69.99/year (previously $99/year).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->