### PR TITLE
feat(legal): GDPR/CCPA/COPPA privacy policy + Terms of Service refresh

### DIFF
--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -50,7 +50,7 @@ export default function PrivacyPage() {
               <a href="mailto:support@screentimehero.com" className="text-[#3A7BFA] hover:underline">
                 support@screentimehero.com
               </a>
-              . See Section 14 for additional contacts including our EU representative.
+              . See Section 14 for any additional jurisdiction-specific contact details that apply.
             </p>
           </section>
 
@@ -418,12 +418,10 @@ export default function PrivacyPage() {
           <section>
             <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">14. EU / UK representative</h2>
             <p className="text-gray-600 leading-relaxed">
-              Under Article 27 of the GDPR and Article 27 of the UK GDPR, our EU and UK representative contact details are provided below. If you are in the EEA, the UK, or Switzerland, you may contact the relevant representative directly with questions about how we handle your personal information.
+              If we appoint an EU or UK representative under Article 27 of the GDPR or UK GDPR, we will publish the relevant contact details here before this policy is published in those regions.
             </p>
             <p className="text-gray-600 leading-relaxed mt-3 italic">
-              EU Representative: [Name], [Address], [Email]
-              <br />
-              UK Representative: [Name], [Address], [Email]
+              [EU / UK representative contact details to be confirmed before publication.]
             </p>
           </section>
         </div>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -53,7 +53,7 @@ export default function PrivacyPage() {
               <a href="mailto:support@screentimehero.com" className="text-[#3A7BFA] hover:underline">
                 support@screentimehero.com
               </a>
-              . See Section 14 for any additional jurisdiction-specific contact details that apply.
+              .
             </p>
           </section>
 

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -3,8 +3,11 @@ import Image from "next/image";
 import type { Metadata } from "next";
 import { SiteFooter } from "@/app/_components/SiteFooter";
 
-const PRIVACY_POLICY_EFFECTIVE_DATE = "April 22, 2026";
 const PRIVACY_POLICY_EFFECTIVE_DATE_ISO = "2026-04-22";
+const PRIVACY_POLICY_EFFECTIVE_DATE = new Intl.DateTimeFormat("en-US", {
+  dateStyle: "long",
+  timeZone: "UTC",
+}).format(new Date(`${PRIVACY_POLICY_EFFECTIVE_DATE_ISO}T00:00:00Z`));
 
 export const metadata: Metadata = {
   title: "Privacy Policy - Screen Time Hero",
@@ -412,16 +415,6 @@ export default function PrivacyPage() {
               <a href="mailto:support@screentimehero.com" className="text-[#3A7BFA] hover:underline">
                 support@screentimehero.com
               </a>
-            </p>
-          </section>
-
-          <section>
-            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">14. EU / UK representative</h2>
-            <p className="text-gray-600 leading-relaxed">
-              If we appoint an EU or UK representative under Article 27 of the GDPR or UK GDPR, we will publish the relevant contact details here before this policy is published in those regions.
-            </p>
-            <p className="text-gray-600 leading-relaxed mt-3 italic">
-              [EU / UK representative contact details to be confirmed before publication.]
             </p>
           </section>
         </div>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -3,6 +3,9 @@ import Image from "next/image";
 import type { Metadata } from "next";
 import { SiteFooter } from "@/app/_components/SiteFooter";
 
+const PRIVACY_POLICY_EFFECTIVE_DATE = "April 22, 2026";
+const PRIVACY_POLICY_EFFECTIVE_DATE_ISO = "2026-04-22";
+
 export const metadata: Metadata = {
   title: "Privacy Policy - Screen Time Hero",
   description:
@@ -28,7 +31,10 @@ export default function PrivacyPage() {
       {/* Content */}
       <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         <h1 className="text-4xl font-bold text-[#1C1F26] mb-2">Privacy Policy</h1>
-        <p className="text-gray-500 mb-8">Effective Date: April 22, 2026</p>
+        <p className="text-gray-500 mb-8">
+          Effective Date:{" "}
+          <time dateTime={PRIVACY_POLICY_EFFECTIVE_DATE_ISO}>{PRIVACY_POLICY_EFFECTIVE_DATE}</time>
+        </p>
 
         <div className="prose prose-gray max-w-none space-y-8">
           <section>
@@ -93,11 +99,12 @@ export default function PrivacyPage() {
             <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">3. Why we use your data and our legal basis (GDPR)</h2>
             <div className="overflow-x-auto">
               <table className="w-full text-left text-gray-600 text-sm border-collapse">
+                <caption className="sr-only">GDPR legal basis by processing purpose</caption>
                 <thead>
                   <tr className="border-b border-gray-200">
-                    <th className="py-2 pr-4 font-semibold text-[#1C1F26]">Purpose</th>
-                    <th className="py-2 pr-4 font-semibold text-[#1C1F26]">Data used</th>
-                    <th className="py-2 font-semibold text-[#1C1F26]">Legal basis (GDPR Art. 6)</th>
+                    <th scope="col" className="py-2 pr-4 font-semibold text-[#1C1F26]">Purpose</th>
+                    <th scope="col" className="py-2 pr-4 font-semibold text-[#1C1F26]">Data used</th>
+                    <th scope="col" className="py-2 font-semibold text-[#1C1F26]">Legal basis (GDPR Art. 6)</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -182,11 +189,12 @@ export default function PrivacyPage() {
             </p>
             <div className="overflow-x-auto mt-4">
               <table className="w-full text-left text-gray-600 text-sm border-collapse">
+                <caption className="sr-only">Service providers and data shared with each</caption>
                 <thead>
                   <tr className="border-b border-gray-200">
-                    <th className="py-2 pr-4 font-semibold text-[#1C1F26]">Provider</th>
-                    <th className="py-2 pr-4 font-semibold text-[#1C1F26]">Role</th>
-                    <th className="py-2 font-semibold text-[#1C1F26]">Data shared</th>
+                    <th scope="col" className="py-2 pr-4 font-semibold text-[#1C1F26]">Provider</th>
+                    <th scope="col" className="py-2 pr-4 font-semibold text-[#1C1F26]">Role</th>
+                    <th scope="col" className="py-2 font-semibold text-[#1C1F26]">Data shared</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -252,10 +260,11 @@ export default function PrivacyPage() {
             </p>
             <div className="overflow-x-auto mt-4">
               <table className="w-full text-left text-gray-600 text-sm border-collapse">
+                <caption className="sr-only">Data retention windows by category</caption>
                 <thead>
                   <tr className="border-b border-gray-200">
-                    <th className="py-2 pr-4 font-semibold text-[#1C1F26]">Category</th>
-                    <th className="py-2 font-semibold text-[#1C1F26]">Retention</th>
+                    <th scope="col" className="py-2 pr-4 font-semibold text-[#1C1F26]">Category</th>
+                    <th scope="col" className="py-2 font-semibold text-[#1C1F26]">Retention</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -409,10 +418,12 @@ export default function PrivacyPage() {
           <section>
             <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">14. EU / UK representative</h2>
             <p className="text-gray-600 leading-relaxed">
-              Under Article 27 of the GDPR and Article 27 of the UK GDPR, we have appointed a representative in the European Union and the United Kingdom. If you are in the EEA, the UK, or Switzerland, you may contact our representative directly for any question about how we handle your personal information.
+              Under Article 27 of the GDPR and Article 27 of the UK GDPR, our EU and UK representative contact details are provided below. If you are in the EEA, the UK, or Switzerland, you may contact the relevant representative directly with questions about how we handle your personal information.
             </p>
             <p className="text-gray-600 leading-relaxed mt-3 italic">
-              [EU / UK representative name and address to be confirmed before launch.]
+              EU Representative: [Name], [Address], [Email]
+              <br />
+              UK Representative: [Name], [Address], [Email]
             </p>
           </section>
         </div>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -5,7 +5,8 @@ import { SiteFooter } from "@/app/_components/SiteFooter";
 
 export const metadata: Metadata = {
   title: "Privacy Policy - Screen Time Hero",
-  description: "Screen Time Hero Privacy Policy. Learn how we collect, use, and protect your data.",
+  description:
+    "Screen Time Hero Privacy Policy. What we collect, how we use it, how long we keep it, who we share it with, and your rights under GDPR, CCPA, and COPPA.",
 };
 
 export default function PrivacyPage() {
@@ -18,138 +19,400 @@ export default function PrivacyPage() {
             <Image src="/logo.svg" alt="Screen Time Hero" width={32} height={32} />
             <span className="text-xl font-bold text-[#1C1F26]">Screen Time Hero</span>
           </Link>
-          <Link href="/" className="text-sm text-[#3A7BFA] hover:underline">Back to Home</Link>
+          <Link href="/" className="text-sm text-[#3A7BFA] hover:underline">
+            Back to Home
+          </Link>
         </div>
       </header>
 
       {/* Content */}
       <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         <h1 className="text-4xl font-bold text-[#1C1F26] mb-2">Privacy Policy</h1>
-        <p className="text-gray-500 mb-8">Effective Date: March 1, 2026</p>
+        <p className="text-gray-500 mb-8">Effective Date: April 22, 2026</p>
 
         <div className="prose prose-gray max-w-none space-y-8">
           <section>
-            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">1. Introduction</h2>
+            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">1. Who we are</h2>
             <p className="text-gray-600 leading-relaxed">
-              Screen Time Hero (&quot;we,&quot; &quot;us,&quot; or &quot;our&quot;) operates the Screen Time Hero mobile application and website (collectively, the &quot;Service&quot;). This Privacy Policy explains how we collect, use, disclose, and safeguard your information when you use our Service. We are committed to protecting the privacy of all our users, especially children.
+              Screen Time Hero (&quot;Screen Time Hero,&quot; &quot;we,&quot; &quot;us,&quot; or &quot;our&quot;) operates the Screen Time Hero mobile application (iOS) and the supporting website at screentimehero.com (together, the &quot;Service&quot;). This Privacy Policy explains what personal information we collect, how we use it, how long we keep it, who we share it with, and the rights you have over it.
+            </p>
+            <p className="text-gray-600 leading-relaxed mt-3">
+              For the purposes of the EU and UK General Data Protection Regulations (&quot;GDPR&quot;) and the California Consumer Privacy Act as amended by the CPRA (&quot;CCPA&quot;), Screen Time Hero is the data controller / business for the personal information described in this policy.
+            </p>
+            <p className="text-gray-600 leading-relaxed mt-3">
+              Questions? Email{" "}
+              <a href="mailto:support@screentimehero.com" className="text-[#3A7BFA] hover:underline">
+                support@screentimehero.com
+              </a>
+              . See Section 14 for additional contacts including our EU representative.
             </p>
           </section>
 
           <section>
-            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">2. Information We Collect</h2>
-            <h3 className="text-lg font-semibold text-[#1C1F26] mt-4 mb-2">Account Information</h3>
-            <ul className="list-disc pl-6 text-gray-600 space-y-1">
-              <li>Parent/guardian name and email address</li>
-              <li>Child&apos;s first name (or nickname)</li>
-              <li>Authentication credentials (via email/password or Apple Sign In)</li>
-            </ul>
-
-            <h3 className="text-lg font-semibold text-[#1C1F26] mt-4 mb-2">Usage Data</h3>
-            <ul className="list-disc pl-6 text-gray-600 space-y-1">
-              <li>Task assignments and completion records</li>
-              <li>Photos submitted as task proof</li>
-              <li>Points earned and rewards redeemed</li>
-              <li>Screen time usage categories (managed through Apple&apos;s FamilyControls framework)</li>
-            </ul>
-
-            <h3 className="text-lg font-semibold text-[#1C1F26] mt-4 mb-2">Technical Data</h3>
-            <ul className="list-disc pl-6 text-gray-600 space-y-1">
-              <li>Device type and operating system version</li>
-              <li>App version</li>
-              <li>Crash logs and performance data</li>
-            </ul>
-          </section>
-
-          <section>
-            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">3. Children&apos;s Privacy (COPPA Compliance)</h2>
+            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">2. What we collect</h2>
             <p className="text-gray-600 leading-relaxed">
-              We comply with the Children&apos;s Online Privacy Protection Act (COPPA). Our Service is designed so that parents or legal guardians create and manage all accounts. We do not knowingly collect personal information directly from children under 13 without verifiable parental consent.
+              We collect only the data we need to operate the Service. We do not use analytics SDKs, we do not track users across apps or websites, and we do not request or use the Advertising Identifier (IDFA).
             </p>
-            <ul className="list-disc pl-6 text-gray-600 space-y-1 mt-3">
-              <li>Child accounts are created and controlled by the parent/guardian</li>
-              <li>We collect only the minimum information necessary (first name or nickname)</li>
-              <li>Parents can review, modify, or delete their child&apos;s data at any time</li>
-              <li>We do not serve advertising to children</li>
-              <li>We do not share children&apos;s data with third parties for marketing purposes</li>
-            </ul>
-          </section>
 
-          <section>
-            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">4. How We Use Your Information</h2>
+            <h3 className="text-lg font-semibold text-[#1C1F26] mt-4 mb-2">From parents when you create an account</h3>
             <ul className="list-disc pl-6 text-gray-600 space-y-1">
-              <li>To provide and maintain the Service</li>
-              <li>To manage task assignments, approvals, and reward redemptions</li>
-              <li>To enforce screen time rules via Apple&apos;s FamilyControls framework</li>
-              <li>To send transactional emails (account verification, password resets, family invitations)</li>
-              <li>To improve and optimize the Service</li>
-              <li>To respond to support requests</li>
+              <li>Email address (required)</li>
+              <li>Name (first and last)</li>
+              <li>Authentication credentials (password stored as a salted hash via Supabase Auth, or a federated identifier if you choose Apple Sign-In or Google Sign-In)</li>
+              <li>Phone number (only if you use the SMS option for parental consent delivery; otherwise not collected)</li>
+              <li>Subscription receipt metadata processed by RevenueCat on our behalf (plan, renewal state, country)</li>
+            </ul>
+
+            <h3 className="text-lg font-semibold text-[#1C1F26] mt-4 mb-2">From you about your child</h3>
+            <ul className="list-disc pl-6 text-gray-600 space-y-1">
+              <li>First name or nickname</li>
+              <li>Birth month and year (used to determine whether COPPA verifiable parental consent is required)</li>
+              <li>Optional avatar photo (only if you upload one)</li>
+            </ul>
+
+            <h3 className="text-lg font-semibold text-[#1C1F26] mt-4 mb-2">Generated while using the Service</h3>
+            <ul className="list-disc pl-6 text-gray-600 space-y-1">
+              <li>Chores assigned, completed, approved, or rejected</li>
+              <li>Rewards created and redeemed, points earned and spent</li>
+              <li>Photos or other proof a child submits for a chore (stored as-is in Supabase Storage)</li>
+              <li>Screen-time rules and aggregated usage summaries produced by Apple&apos;s FamilyControls framework. The app-usage tokens themselves are opaque on-device identifiers defined by Apple; we never receive or store real bundle IDs.</li>
+              <li>Extension-of-time requests from a child and the parent&apos;s decision on each</li>
+              <li>Messages your device exchanges with our backend for the Service to function (task approvals, push notifications, etc.)</li>
+            </ul>
+
+            <h3 className="text-lg font-semibold text-[#1C1F26] mt-4 mb-2">Operational and security data</h3>
+            <ul className="list-disc pl-6 text-gray-600 space-y-1">
+              <li>Device push tokens so we can deliver Apple Push Notifications</li>
+              <li>Login session tokens (JWT), password-reset codes, and session IP address</li>
+              <li>Rate-limit counters and short-lived audit log rows so we can detect abuse</li>
+              <li>Anonymous device fingerprint and the IP address / user agent recorded at the time a parent grants verifiable parental consent (required under 16 CFR §312.8)</li>
             </ul>
           </section>
 
           <section>
-            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">5. Third-Party Services</h2>
-            <p className="text-gray-600 leading-relaxed">We use the following third-party services:</p>
-            <ul className="list-disc pl-6 text-gray-600 space-y-1 mt-3">
-              <li><strong>Supabase</strong> — Database hosting and file storage (photos). Data is encrypted at rest and in transit.</li>
-              <li><strong>Apple Sign In</strong> — Optional authentication method. We receive only the information you authorize Apple to share.</li>
-              <li><strong>Resend</strong> — Transactional email delivery (invitations, password resets). We share only the recipient&apos;s email address.</li>
-              <li><strong>Apple FamilyControls</strong> — Screen time enforcement. App usage tokens are opaque and processed on-device only.</li>
-              <li><strong>Vercel</strong> — Website hosting.</li>
-              <li><strong>Railway</strong> — API server hosting.</li>
+            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">3. Why we use your data and our legal basis (GDPR)</h2>
+            <div className="overflow-x-auto">
+              <table className="w-full text-left text-gray-600 text-sm border-collapse">
+                <thead>
+                  <tr className="border-b border-gray-200">
+                    <th className="py-2 pr-4 font-semibold text-[#1C1F26]">Purpose</th>
+                    <th className="py-2 pr-4 font-semibold text-[#1C1F26]">Data used</th>
+                    <th className="py-2 font-semibold text-[#1C1F26]">Legal basis (GDPR Art. 6)</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr className="border-b border-gray-100">
+                    <td className="py-2 pr-4">Create and operate your account</td>
+                    <td className="py-2 pr-4">Account information</td>
+                    <td className="py-2">Performance of a contract &mdash; 6(1)(b)</td>
+                  </tr>
+                  <tr className="border-b border-gray-100">
+                    <td className="py-2 pr-4">Deliver parental-control features (chores, rewards, screen time)</td>
+                    <td className="py-2 pr-4">Child profile, usage data, proofs</td>
+                    <td className="py-2">Performance of a contract &mdash; 6(1)(b)</td>
+                  </tr>
+                  <tr className="border-b border-gray-100">
+                    <td className="py-2 pr-4">Obtain verifiable parental consent under COPPA</td>
+                    <td className="py-2 pr-4">Parent contact (hashed), consent audit trail</td>
+                    <td className="py-2">Legal obligation &mdash; 6(1)(c) (U.S.); consent &mdash; 6(1)(a) (EEA/UK)</td>
+                  </tr>
+                  <tr className="border-b border-gray-100">
+                    <td className="py-2 pr-4">Process subscriptions and receipts</td>
+                    <td className="py-2 pr-4">Purchase history via RevenueCat</td>
+                    <td className="py-2">Performance of a contract &mdash; 6(1)(b)</td>
+                  </tr>
+                  <tr className="border-b border-gray-100">
+                    <td className="py-2 pr-4">Prevent abuse, enforce rate limits, debug incidents</td>
+                    <td className="py-2 pr-4">Session IP, device fingerprint, request logs</td>
+                    <td className="py-2">Legitimate interests &mdash; 6(1)(f) (fraud prevention and service security)</td>
+                  </tr>
+                  <tr className="border-b border-gray-100">
+                    <td className="py-2 pr-4">Respond to support requests</td>
+                    <td className="py-2 pr-4">Anything you send us</td>
+                    <td className="py-2">Legitimate interests &mdash; 6(1)(f)</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <p className="text-gray-600 leading-relaxed mt-4">
+              We never use your data for behavioral advertising, profiling, or automated decision-making with legal or similarly significant effect.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">4. Children&apos;s privacy (COPPA)</h2>
+            <p className="text-gray-600 leading-relaxed">
+              Screen Time Hero complies with the Children&apos;s Online Privacy Protection Act (COPPA, 16 CFR Part 312) for children under 13 in the United States.
+            </p>
+            <h3 className="text-lg font-semibold text-[#1C1F26] mt-4 mb-2">Verifiable parental consent</h3>
+            <p className="text-gray-600 leading-relaxed">
+              When a child under 13 is introduced into the app &mdash; either by a parent adding them, or by the child attempting to sign up &mdash; we require verifiable parental consent before collecting, using, or disclosing the child&apos;s personal information. We currently offer the &quot;email-plus&quot; consent method under §312.5(b)(2): we send the parent a consent link via email (or SMS, at the parent&apos;s choice), and record the consent along with the time, parent IP, user agent, and the privacy-policy version in effect.
+            </p>
+            <h3 className="text-lg font-semibold text-[#1C1F26] mt-4 mb-2">Parental controls</h3>
+            <p className="text-gray-600 leading-relaxed">
+              A parent (or legal guardian) can at any time, from inside the app:
+            </p>
+            <ul className="list-disc pl-6 text-gray-600 space-y-1 mt-2">
+              <li>
+                <strong>Review</strong> everything we hold about a specific child &mdash; open the child&apos;s Settings and tap <em>Data &amp; Privacy &rarr; Download</em>.
+              </li>
+              <li>
+                <strong>Correct</strong> information by editing the child&apos;s profile.
+              </li>
+              <li>
+                <strong>Delete</strong> the child&apos;s account and all associated data &mdash; open the child&apos;s Settings and tap <em>Data &amp; Privacy &rarr; Delete</em>. This is an immediate, hard delete, not a soft delete.
+              </li>
+              <li>
+                <strong>Withdraw consent</strong> for any further collection by deleting the child&apos;s account.
+              </li>
+            </ul>
+            <h3 className="text-lg font-semibold text-[#1C1F26] mt-4 mb-2">What we do not do</h3>
+            <ul className="list-disc pl-6 text-gray-600 space-y-1">
+              <li>We do not serve advertising to children.</li>
+              <li>We do not enable or permit children to make personal information publicly available.</li>
+              <li>We do not disclose children&apos;s personal information to third parties for their own marketing.</li>
+              <li>We collect only the personal information reasonably necessary to provide the parental-control features the parent signed up for.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">5. Who we share data with</h2>
+            <p className="text-gray-600 leading-relaxed">
+              We share personal information only with the service providers who help us operate Screen Time Hero. Each is contractually bound by a Data Processing Agreement (or the equivalent under CCPA) to process the data only on our behalf and only for the purposes listed here.
+            </p>
+            <div className="overflow-x-auto mt-4">
+              <table className="w-full text-left text-gray-600 text-sm border-collapse">
+                <thead>
+                  <tr className="border-b border-gray-200">
+                    <th className="py-2 pr-4 font-semibold text-[#1C1F26]">Provider</th>
+                    <th className="py-2 pr-4 font-semibold text-[#1C1F26]">Role</th>
+                    <th className="py-2 font-semibold text-[#1C1F26]">Data shared</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr className="border-b border-gray-100">
+                    <td className="py-2 pr-4">Supabase</td>
+                    <td className="py-2 pr-4">Database, authentication, file storage</td>
+                    <td className="py-2">All application data at rest</td>
+                  </tr>
+                  <tr className="border-b border-gray-100">
+                    <td className="py-2 pr-4">Railway</td>
+                    <td className="py-2 pr-4">API server hosting</td>
+                    <td className="py-2">Transient request/response data and operational logs</td>
+                  </tr>
+                  <tr className="border-b border-gray-100">
+                    <td className="py-2 pr-4">Vercel</td>
+                    <td className="py-2 pr-4">Website + consent-landing-page hosting</td>
+                    <td className="py-2">Web request metadata</td>
+                  </tr>
+                  <tr className="border-b border-gray-100">
+                    <td className="py-2 pr-4">RevenueCat</td>
+                    <td className="py-2 pr-4">Subscription and purchase management</td>
+                    <td className="py-2">App user ID, purchase receipts, plan state</td>
+                  </tr>
+                  <tr className="border-b border-gray-100">
+                    <td className="py-2 pr-4">Apple</td>
+                    <td className="py-2 pr-4">Sign in with Apple, Push Notifications, FamilyControls / Screen Time APIs</td>
+                    <td className="py-2">Apple-provided identifier and device push token; screen-time tokens remain on-device</td>
+                  </tr>
+                  <tr className="border-b border-gray-100">
+                    <td className="py-2 pr-4">Google</td>
+                    <td className="py-2 pr-4">Sign in with Google (optional)</td>
+                    <td className="py-2">Google-provided identifier and basic profile you authorize</td>
+                  </tr>
+                  <tr className="border-b border-gray-100">
+                    <td className="py-2 pr-4">Resend</td>
+                    <td className="py-2 pr-4">Transactional email (invitations, consent links, password resets)</td>
+                    <td className="py-2">Recipient email address and email contents</td>
+                  </tr>
+                  <tr className="border-b border-gray-100">
+                    <td className="py-2 pr-4">Twilio</td>
+                    <td className="py-2 pr-4">SMS delivery (parental consent via SMS, if selected)</td>
+                    <td className="py-2">Recipient phone number and SMS body</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <p className="text-gray-600 leading-relaxed mt-4">
+              We do not sell personal information and we do not share personal information for cross-context behavioral advertising. We may disclose information when required by law, subpoena, or a court order, or to protect the rights, property, or safety of Screen Time Hero, our users, or the public.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">6. International data transfers</h2>
+            <p className="text-gray-600 leading-relaxed">
+              Screen Time Hero operates from the United States, and our service providers (listed in Section 5) store and process data primarily in the United States. If you are located in the European Economic Area, the United Kingdom, or Switzerland, your personal information is transferred to the United States. We rely on the European Commission&apos;s Standard Contractual Clauses (and the UK International Data Transfer Addendum where applicable) as the lawful mechanism for those transfers, which we have in place with each service provider named above.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">7. How long we keep your data</h2>
+            <p className="text-gray-600 leading-relaxed">
+              We keep personal information only for as long as we need it for the purposes in Section 3. The concrete windows are:
+            </p>
+            <div className="overflow-x-auto mt-4">
+              <table className="w-full text-left text-gray-600 text-sm border-collapse">
+                <thead>
+                  <tr className="border-b border-gray-200">
+                    <th className="py-2 pr-4 font-semibold text-[#1C1F26]">Category</th>
+                    <th className="py-2 font-semibold text-[#1C1F26]">Retention</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr className="border-b border-gray-100">
+                    <td className="py-2 pr-4">Parent and child accounts (profiles, chores, rewards, usage, proofs)</td>
+                    <td className="py-2">Until you delete the account. Deletion is immediate and hard &mdash; not a soft delete.</td>
+                  </tr>
+                  <tr className="border-b border-gray-100">
+                    <td className="py-2 pr-4">Verifiable parental consent records</td>
+                    <td className="py-2">90 days after the consent request is resolved (granted, expired, or revoked). The consent outcome snapshot stays on the child&apos;s profile until the profile is deleted.</td>
+                  </tr>
+                  <tr className="border-b border-gray-100">
+                    <td className="py-2 pr-4">Password-reset codes and tokens</td>
+                    <td className="py-2">7 days after the code or token expires</td>
+                  </tr>
+                  <tr className="border-b border-gray-100">
+                    <td className="py-2 pr-4">Rate-limit state</td>
+                    <td className="py-2">30 days after the last action</td>
+                  </tr>
+                  <tr className="border-b border-gray-100">
+                    <td className="py-2 pr-4">Host-level logs (Railway)</td>
+                    <td className="py-2">30 days rolling</td>
+                  </tr>
+                  <tr className="border-b border-gray-100">
+                    <td className="py-2 pr-4">Encrypted database backups (Supabase)</td>
+                    <td className="py-2">Supabase point-in-time-recovery window. Deleted data ages out of backups within that window.</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <p className="text-gray-600 leading-relaxed mt-4">
+              These windows are enforced automatically by purge jobs that run daily.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">8. Your rights (GDPR / UK GDPR)</h2>
+            <p className="text-gray-600 leading-relaxed">
+              If the GDPR applies to your processing, you have the right to:
+            </p>
+            <ul className="list-disc pl-6 text-gray-600 space-y-1 mt-2">
+              <li>
+                <strong>Access</strong> the personal data we hold about you &mdash; tap <em>Settings &rarr; Download my data</em> in the app. For a specific child, use <em>Data &amp; Privacy &rarr; Download</em> on that child&apos;s profile. Both return a machine-readable JSON bundle.
+              </li>
+              <li>
+                <strong>Rectify</strong> inaccurate personal data &mdash; edit the profile in the app.
+              </li>
+              <li>
+                <strong>Erase</strong> your personal data &mdash; tap <em>Settings &rarr; Delete Account</em>. For a specific child, use <em>Data &amp; Privacy &rarr; Delete</em>.
+              </li>
+              <li>
+                <strong>Restrict</strong> or <strong>object to</strong> certain processing &mdash; email us and we will honor the request where the law allows.
+              </li>
+              <li>
+                <strong>Portability</strong> &mdash; the Download action above produces a portable JSON file.
+              </li>
+              <li>
+                <strong>Withdraw consent</strong> where we rely on consent (primarily COPPA) &mdash; delete the child account.
+              </li>
+              <li>
+                <strong>Lodge a complaint</strong> with your local supervisory authority. In the UK it is the Information Commissioner&apos;s Office (ico.org.uk).
+              </li>
+            </ul>
+            <p className="text-gray-600 leading-relaxed mt-4">
+              We do not charge a fee for exercising these rights. We respond to requests within 30 days (extendable by up to two additional months for complex requests, with notice to you).
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">9. California residents (CCPA / CPRA)</h2>
+            <p className="text-gray-600 leading-relaxed">
+              This section applies if you are a California resident.
+            </p>
+
+            <h3 className="text-lg font-semibold text-[#1C1F26] mt-4 mb-2">Categories of personal information collected in the last 12 months</h3>
+            <ul className="list-disc pl-6 text-gray-600 space-y-1 mt-2">
+              <li><strong>Identifiers</strong> &mdash; name, email, account ID, device ID, IP address</li>
+              <li><strong>Customer records (Cal. Civ. Code §1798.80(e))</strong> &mdash; phone number (optional)</li>
+              <li><strong>Commercial information</strong> &mdash; subscription plan, purchase history (via RevenueCat)</li>
+              <li><strong>Internet or other electronic network activity</strong> &mdash; app request logs, rate-limit counters, consent-audit IP and user agent</li>
+              <li><strong>Audio, electronic, visual information</strong> &mdash; child-submitted chore photos (only if uploaded)</li>
+              <li><strong>Information about minors under 16</strong> &mdash; the age and activity information a parent provides about a child</li>
+            </ul>
+
+            <h3 className="text-lg font-semibold text-[#1C1F26] mt-4 mb-2">Sources</h3>
+            <p className="text-gray-600 leading-relaxed">
+              Directly from you when you sign up or use the app, and from the service providers listed in Section 5 when they act on our behalf (e.g., RevenueCat when you complete a subscription).
+            </p>
+
+            <h3 className="text-lg font-semibold text-[#1C1F26] mt-4 mb-2">Business purposes</h3>
+            <p className="text-gray-600 leading-relaxed">
+              See Section 3 above. In CCPA terms: performing services, fraud prevention, security, and legal compliance.
+            </p>
+
+            <h3 className="text-lg font-semibold text-[#1C1F26] mt-4 mb-2">Sale or sharing</h3>
+            <p className="text-gray-600 leading-relaxed">
+              <strong>We do not sell personal information and we do not share personal information for cross-context behavioral advertising.</strong> We have not done so in the last 12 months. We do not sell or share the personal information of anyone under 16.
+            </p>
+
+            <h3 className="text-lg font-semibold text-[#1C1F26] mt-4 mb-2">Your California rights</h3>
+            <ul className="list-disc pl-6 text-gray-600 space-y-1 mt-2">
+              <li>Right to know what personal information we collect, use, disclose, and retain</li>
+              <li>Right to delete personal information we have collected</li>
+              <li>Right to correct inaccurate personal information</li>
+              <li>Right to limit the use of sensitive personal information (we do not use sensitive PI beyond the purposes allowed without a right-to-limit)</li>
+              <li>Right to non-discrimination for exercising these rights</li>
             </ul>
             <p className="text-gray-600 leading-relaxed mt-3">
-              We do not sell your personal information to any third party.
+              You can exercise the Right to Know and the Right to Delete directly in the app (see Section 8), or by emailing{" "}
+              <a href="mailto:support@screentimehero.com" className="text-[#3A7BFA] hover:underline">
+                support@screentimehero.com
+              </a>
+              . We verify requests by confirming you have access to the account email on file. Authorized agents may submit requests on your behalf with written authorization.
             </p>
           </section>
 
           <section>
-            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">6. Data Security</h2>
+            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">10. Security</h2>
             <p className="text-gray-600 leading-relaxed">
-              We implement industry-standard security measures to protect your data, including TLS 1.2+ encryption in transit, AES-256 encryption at rest, and secure authentication with JWT tokens. However, no method of electronic transmission or storage is 100% secure, and we cannot guarantee absolute security.
+              We protect personal information with industry-standard measures, including TLS 1.2+ encryption in transit, encryption at rest for Supabase data and storage, salted password hashing, JWT-based session tokens, signed-URL access to stored files, server-side rate limiting, and least-privilege row-level security policies. No system is perfectly secure. If we experience a data breach that affects your personal information, we will notify you and the relevant regulators as required by applicable law.
             </p>
           </section>
 
           <section>
-            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">7. Data Retention and Deletion</h2>
+            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">11. Tracking and advertising</h2>
             <p className="text-gray-600 leading-relaxed">
-              We retain your data for as long as your account is active. You can request deletion of your account and all associated data at any time by contacting us at support@screentimehero.com. Upon account deletion:
-            </p>
-            <ul className="list-disc pl-6 text-gray-600 space-y-1 mt-3">
-              <li>All personal information is permanently deleted within 30 days</li>
-              <li>Photos submitted as task proof are permanently deleted</li>
-              <li>Child account data is deleted along with the parent account</li>
-            </ul>
-          </section>
-
-          <section>
-            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">8. Your Rights</h2>
-            <p className="text-gray-600 leading-relaxed">You have the right to:</p>
-            <ul className="list-disc pl-6 text-gray-600 space-y-1 mt-3">
-              <li>Access the personal information we hold about you and your children</li>
-              <li>Correct inaccurate information</li>
-              <li>Request deletion of your data</li>
-              <li>Withdraw consent for data processing</li>
-              <li>Export your data in a portable format</li>
-            </ul>
-          </section>
-
-          <section>
-            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">9. Changes to This Policy</h2>
-            <p className="text-gray-600 leading-relaxed">
-              We may update this Privacy Policy from time to time. We will notify you of any material changes by posting the new policy on this page and updating the effective date. We encourage you to review this policy periodically.
+              Screen Time Hero does not use third-party analytics SDKs, crash-reporting SDKs, or behavioral advertising tools. We do not request Apple&apos;s App Tracking Transparency permission because we do not track you across other apps or websites. We do not respond to any particular browser Do Not Track signal because none are applicable &mdash; there is no tracking to disable.
             </p>
           </section>
 
           <section>
-            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">10. Contact Us</h2>
+            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">12. Changes to this policy</h2>
             <p className="text-gray-600 leading-relaxed">
-              If you have questions about this Privacy Policy or our data practices, please contact us at:
+              When we make a material change we will update the &quot;Effective Date&quot; at the top of this page and, where practicable, notify you in-app or by email before the change takes effect. We keep prior versions on request.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">13. Contact us</h2>
+            <p className="text-gray-600 leading-relaxed">
+              For any question about this Privacy Policy, or to exercise any of the rights above:
             </p>
             <p className="text-gray-600 mt-3">
               <strong>Email:</strong>{" "}
               <a href="mailto:support@screentimehero.com" className="text-[#3A7BFA] hover:underline">
                 support@screentimehero.com
               </a>
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">14. EU / UK representative</h2>
+            <p className="text-gray-600 leading-relaxed">
+              Under Article 27 of the GDPR and Article 27 of the UK GDPR, we have appointed a representative in the European Union and the United Kingdom. If you are in the EEA, the UK, or Switzerland, you may contact our representative directly for any question about how we handle your personal information.
+            </p>
+            <p className="text-gray-600 leading-relaxed mt-3 italic">
+              [EU / UK representative name and address to be confirmed before launch.]
             </p>
           </section>
         </div>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -417,6 +417,16 @@ export default function PrivacyPage() {
               </a>
             </p>
           </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">14. Where the Service is offered</h2>
+            <p className="text-gray-600 leading-relaxed">
+              Screen Time Hero is currently offered only in the United States, Canada, and Australia. The app is distributed through the Apple App Store in those territories only. We do not offer the Service, market the Service, or knowingly collect personal information from residents of the European Economic Area, the United Kingdom, or Switzerland at this time.
+            </p>
+            <p className="text-gray-600 leading-relaxed mt-3">
+              The GDPR and UK GDPR references in this policy (Sections 1, 3, 6, and 8) are retained as a defensive measure in case a resident of those regions accesses the Service despite the territory restriction. When we expand into the EEA, the UK, or Switzerland we will update this policy, designate a representative under Article 27 of the GDPR and UK GDPR, and publish the representative&apos;s contact information here before making the Service available in those regions.
+            </p>
+          </section>
         </div>
       </main>
 

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -5,7 +5,8 @@ import { SiteFooter } from "@/app/_components/SiteFooter";
 
 export const metadata: Metadata = {
   title: "Terms of Service - Screen Time Hero",
-  description: "Screen Time Hero Terms of Service. Read our terms and conditions for using the service.",
+  description:
+    "Screen Time Hero Terms of Service. The agreement between you and Screen Time Hero covering account use, subscriptions, parental responsibilities, and dispute resolution.",
 };
 
 export default function TermsPage() {
@@ -25,124 +26,201 @@ export default function TermsPage() {
       {/* Content */}
       <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         <h1 className="text-4xl font-bold text-[#1C1F26] mb-2">Terms of Service</h1>
-        <p className="text-gray-500 mb-8">Effective Date: March 1, 2026</p>
+        <p className="text-gray-500 mb-8">Effective Date: April 22, 2026</p>
 
         <div className="prose prose-gray max-w-none space-y-8">
           <section>
-            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">1. Acceptance of Terms</h2>
+            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">1. Agreement</h2>
             <p className="text-gray-600 leading-relaxed">
-              By accessing or using the Screen Time Hero application and website (the &quot;Service&quot;), you agree to be bound by these Terms of Service (&quot;Terms&quot;). If you do not agree to these Terms, do not use the Service. These Terms constitute a legally binding agreement between you and Screen Time Hero (&quot;we,&quot; &quot;us,&quot; or &quot;our&quot;).
+              These Terms of Service (&quot;Terms&quot;) govern your use of the Screen Time Hero mobile application and the website at screentimehero.com (together, the &quot;Service&quot;), operated by Screen Time Hero (&quot;Screen Time Hero,&quot; &quot;we,&quot; &quot;us,&quot; or &quot;our&quot;). By creating an account or using the Service you agree to these Terms and to our{" "}
+              <Link href="/privacy" className="text-[#3A7BFA] hover:underline">Privacy Policy</Link>. If you do not agree, do not use the Service.
             </p>
           </section>
 
           <section>
-            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">2. Eligibility</h2>
+            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">2. Eligibility and roles</h2>
             <p className="text-gray-600 leading-relaxed">
-              You must be at least 18 years of age to create a parent account and use the Service. By creating an account, you represent that you are the parent or legal guardian of any children added to the Service. Child accounts may only be created and managed by a parent or legal guardian.
-            </p>
-          </section>
-
-          <section>
-            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">3. Account Terms</h2>
-            <ul className="list-disc pl-6 text-gray-600 space-y-2">
-              <li>You are responsible for maintaining the security of your account credentials.</li>
-              <li>You are responsible for all activity that occurs under your account.</li>
-              <li>You must provide accurate and complete information when creating your account.</li>
-              <li>You must not use the Service for any illegal or unauthorized purpose.</li>
-              <li>You are responsible for all content uploaded through your account, including photos submitted as task proof.</li>
-            </ul>
-          </section>
-
-          <section>
-            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">4. Parental Consent</h2>
-            <p className="text-gray-600 leading-relaxed">
-              By creating child accounts within the Service, you confirm that you are the parent or legal guardian of the child and consent to the collection and use of their information as described in our Privacy Policy. You may review, modify, or delete your child&apos;s information at any time through your account settings or by contacting us.
-            </p>
-          </section>
-
-          <section>
-            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">5. Acceptable Use</h2>
-            <p className="text-gray-600 leading-relaxed mb-3">You agree not to:</p>
-            <ul className="list-disc pl-6 text-gray-600 space-y-2">
-              <li>Use the Service in violation of any applicable law or regulation</li>
-              <li>Upload content that is illegal, harmful, threatening, abusive, or otherwise objectionable</li>
-              <li>Attempt to gain unauthorized access to other accounts or our systems</li>
-              <li>Interfere with or disrupt the Service or its infrastructure</li>
-              <li>Use automated means (bots, scrapers) to access the Service without permission</li>
-              <li>Reverse-engineer, decompile, or disassemble any part of the Service</li>
-              <li>Resell or redistribute the Service without authorization</li>
-            </ul>
-          </section>
-
-          <section>
-            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">6. Subscriptions and Payments</h2>
-            <p className="text-gray-600 leading-relaxed">
-              Screen Time Hero offers subscription-based access. By subscribing, you agree to pay the applicable fees. Subscriptions automatically renew unless cancelled before the renewal date. You may cancel your subscription at any time; access continues until the end of the current billing period. Refunds are handled in accordance with Apple App Store policies.
-            </p>
-          </section>
-
-          <section>
-            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">7. Screen Time Enforcement</h2>
-            <p className="text-gray-600 leading-relaxed">
-              Screen Time Hero uses Apple&apos;s FamilyControls framework to manage screen time on children&apos;s devices. While we strive for reliable enforcement, we cannot guarantee uninterrupted operation due to factors outside our control, including iOS updates, device settings, or Apple framework changes. The Service is a tool to assist parents and is not a substitute for parental oversight.
-            </p>
-          </section>
-
-          <section>
-            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">8. Intellectual Property</h2>
-            <p className="text-gray-600 leading-relaxed">
-              The Service and its original content, features, and functionality are owned by Screen Time Hero and are protected by copyright, trademark, and other intellectual property laws. You may not copy, modify, distribute, sell, or lease any part of the Service without our written permission.
+              You must be at least 18 years old and have the legal capacity to form a binding contract to create a parent account. By creating an account you represent that you are the parent or legal guardian of every child you add or invite, and you consent on their behalf to the collection and use of personal information as described in the Privacy Policy.
             </p>
             <p className="text-gray-600 leading-relaxed mt-3">
-              You retain ownership of all content you upload to the Service (such as photos). By uploading content, you grant us a limited license to store, process, and display that content as necessary to provide the Service.
+              Child accounts are created and controlled by a parent account. Children may interact with the Service only under the parent&apos;s supervision and only within the scope the parent allows.
             </p>
           </section>
 
           <section>
-            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">9. Disclaimer of Warranties</h2>
+            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">3. Account security</h2>
+            <ul className="list-disc pl-6 text-gray-600 space-y-2">
+              <li>Keep your credentials confidential.</li>
+              <li>You are responsible for all activity that occurs under your account.</li>
+              <li>Tell us immediately at{" "}
+                <a href="mailto:support@screentimehero.com" className="text-[#3A7BFA] hover:underline">support@screentimehero.com</a>
+                {" "}if you believe your account has been accessed without authorization.
+              </li>
+              <li>Provide accurate and current information and keep it up to date.</li>
+              <li>You are responsible for any content you or your child uploads through your account, including photos submitted as chore proof.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">4. Parental consent and children&apos;s data</h2>
             <p className="text-gray-600 leading-relaxed">
-              THE SERVICE IS PROVIDED &quot;AS IS&quot; AND &quot;AS AVAILABLE&quot; WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT. WE DO NOT WARRANT THAT THE SERVICE WILL BE UNINTERRUPTED, ERROR-FREE, OR COMPLETELY SECURE.
+              Before collecting personal information from a child under 13, we request verifiable parental consent as described in Section 4 of the Privacy Policy. By completing the consent flow you represent that you are that child&apos;s parent or legal guardian.
+            </p>
+            <p className="text-gray-600 leading-relaxed mt-3">
+              You may at any time review, correct, or delete your child&apos;s information from inside the app. From a child&apos;s Settings, tap <em>Data &amp; Privacy</em> to download or delete. From your own Settings, tap <em>Download my data</em> or <em>Delete Account</em> to exercise the same rights on your own data.
             </p>
           </section>
 
           <section>
-            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">10. Limitation of Liability</h2>
+            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">5. Acceptable use</h2>
+            <p className="text-gray-600 leading-relaxed mb-3">You agree not to:</p>
+            <ul className="list-disc pl-6 text-gray-600 space-y-2">
+              <li>Use the Service in violation of any applicable law or regulation;</li>
+              <li>Upload content that is illegal, sexually explicit, exploitative of minors, threatening, abusive, harassing, defamatory, or otherwise objectionable;</li>
+              <li>Use the Service to surveil, stalk, or control any person beyond the parental-oversight role the Service is designed for;</li>
+              <li>Attempt to gain unauthorized access to other accounts, our systems, or the underlying infrastructure;</li>
+              <li>Interfere with or disrupt the Service, its infrastructure, or any user&apos;s use of it;</li>
+              <li>Use automated means (bots, scrapers) to access the Service without our written permission;</li>
+              <li>Reverse-engineer, decompile, or disassemble any part of the Service, except to the minimum extent permitted by applicable law;</li>
+              <li>Resell, sublicense, or redistribute the Service without authorization.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">6. Subscriptions, auto-renewal, and refunds</h2>
             <p className="text-gray-600 leading-relaxed">
-              TO THE MAXIMUM EXTENT PERMITTED BY LAW, SCREEN TIME HERO SHALL NOT BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, OR ANY LOSS OF PROFITS OR REVENUES, WHETHER INCURRED DIRECTLY OR INDIRECTLY, OR ANY LOSS OF DATA, USE, GOODWILL, OR OTHER INTANGIBLE LOSSES, RESULTING FROM YOUR USE OF THE SERVICE. OUR TOTAL LIABILITY SHALL NOT EXCEED THE AMOUNT YOU PAID US IN THE TWELVE (12) MONTHS PRECEDING THE CLAIM.
+              Screen Time Hero offers auto-renewing subscriptions sold through the Apple App Store. By starting a subscription you authorize your Apple ID account to be charged the applicable fee at the start of each billing period. Subscriptions renew automatically at the same price and for the same term unless cancelled at least 24 hours before the renewal date.
+            </p>
+            <p className="text-gray-600 leading-relaxed mt-3">
+              You can manage or cancel your subscription at any time under <em>Apple ID &rarr; Subscriptions</em> on your device. Cancellation takes effect at the end of the current billing period; you keep access until then. Free trials, where offered, convert to paid unless cancelled before the trial ends.
+            </p>
+            <p className="text-gray-600 leading-relaxed mt-3">
+              Refunds are handled by Apple under the App Store&apos;s refund policy. We do not process refunds directly. If you are an EEA or UK consumer, you may have a statutory right of withdrawal within 14 days of purchase; Apple implements that right on our behalf through the App Store refund flow.
             </p>
           </section>
 
           <section>
-            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">11. Termination</h2>
+            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">7. Screen-time enforcement</h2>
             <p className="text-gray-600 leading-relaxed">
-              We may terminate or suspend your account at any time for violation of these Terms, with or without notice. You may terminate your account at any time by contacting us. Upon termination, your right to use the Service ceases immediately. Provisions that by their nature should survive termination (including intellectual property, disclaimers, and limitations of liability) shall survive.
+              The Service uses Apple&apos;s FamilyControls and DeviceActivity frameworks to apply screen-time rules on a child&apos;s device. Enforcement depends on Apple&apos;s frameworks and on the child&apos;s device being set up correctly with Family Sharing. We cannot guarantee uninterrupted enforcement because iOS updates, device configuration changes, or Apple framework changes can affect behavior outside our control.
+            </p>
+            <p className="text-gray-600 leading-relaxed mt-3">
+              The Service is a tool to assist parents in setting and enforcing limits. It is not a substitute for parental oversight or for keeping a child&apos;s device physically secure.
             </p>
           </section>
 
           <section>
-            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">12. Changes to These Terms</h2>
+            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">8. Your content and license</h2>
             <p className="text-gray-600 leading-relaxed">
-              We reserve the right to modify these Terms at any time. We will notify you of material changes by posting the updated Terms on this page and updating the effective date. Your continued use of the Service after changes constitutes acceptance of the new Terms.
+              You retain ownership of the content you or your child upload to the Service (for example, chore-proof photos). By uploading content you grant Screen Time Hero a worldwide, non-exclusive, royalty-free license to store, process, display, and transmit that content solely as needed to provide the Service to you and your family. This license ends when the content is deleted from the Service, except to the extent the content survives in encrypted backups until those backups age out of the retention window described in the Privacy Policy.
+            </p>
+            <p className="text-gray-600 leading-relaxed mt-3">
+              The Service itself &mdash; including the app, website, design, logos, and source code &mdash; is owned by Screen Time Hero and its licensors and is protected by copyright, trademark, and other intellectual-property laws. You may use the Service only as these Terms allow.
             </p>
           </section>
 
           <section>
-            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">13. Governing Law</h2>
+            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">9. DMCA / copyright</h2>
             <p className="text-gray-600 leading-relaxed">
-              These Terms shall be governed by and construed in accordance with the laws of the United States, without regard to conflict of law principles.
+              If you believe content on the Service infringes your copyright, send a written notice meeting the requirements of 17 U.S.C. §512(c)(3) to{" "}
+              <a href="mailto:support@screentimehero.com" className="text-[#3A7BFA] hover:underline">support@screentimehero.com</a>
+              {" "}with the subject line &quot;DMCA Notice&quot;. Include the infringed work, the infringing material, your contact information, a good-faith statement, a statement under penalty of perjury that you are authorized to act for the rights holder, and your physical or electronic signature. We may remove material, disable access, or terminate repeat-infringer accounts.
             </p>
           </section>
 
           <section>
-            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">14. Contact Us</h2>
+            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">10. Apple App Store terms</h2>
             <p className="text-gray-600 leading-relaxed">
-              If you have questions about these Terms, please contact us at:
+              If you obtained the Screen Time Hero app from the Apple App Store, the Apple Licensed Application End-User License Agreement also applies. You and we acknowledge that these Terms are between you and Screen Time Hero, not Apple, and that Screen Time Hero (not Apple) is responsible for the Service and its content. Apple has no obligation to furnish any maintenance or support for the Service. You represent that you are not located in a country subject to a U.S. Government embargo or designated as a terrorist-supporting country, and that you are not on any U.S. Government list of prohibited or restricted parties. Apple and its subsidiaries are third-party beneficiaries of these Terms and may enforce them against you.
             </p>
-            <p className="text-gray-600 mt-3">
-              <strong>Email:</strong>{" "}
-              <a href="mailto:support@screentimehero.com" className="text-[#3A7BFA] hover:underline">
-                support@screentimehero.com
-              </a>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">11. Disclaimer of warranties</h2>
+            <p className="text-gray-600 leading-relaxed">
+              THE SERVICE IS PROVIDED &quot;AS IS&quot; AND &quot;AS AVAILABLE,&quot; WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT. WE DO NOT WARRANT THAT THE SERVICE WILL BE UNINTERRUPTED, ERROR-FREE, OR FULLY SECURE, OR THAT SCREEN-TIME ENFORCEMENT WILL PREVENT ALL UNAUTHORIZED ACCESS TO APPS OR CONTENT ON A CHILD&apos;S DEVICE.
+            </p>
+            <p className="text-gray-600 leading-relaxed mt-3">
+              Some jurisdictions do not allow the exclusion of implied warranties, so some of these exclusions may not apply to you. Nothing in these Terms limits statutory consumer rights that cannot be waived by contract (including rights consumers have under EEA or UK consumer law).
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">12. Limitation of liability</h2>
+            <p className="text-gray-600 leading-relaxed">
+              TO THE MAXIMUM EXTENT PERMITTED BY LAW, SCREEN TIME HERO AND ITS OFFICERS, DIRECTORS, EMPLOYEES, AND AGENTS WILL NOT BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, EXEMPLARY, OR PUNITIVE DAMAGES, OR ANY LOSS OF PROFITS, REVENUE, DATA, USE, OR GOODWILL, RESULTING FROM YOUR USE OF OR INABILITY TO USE THE SERVICE. OUR AGGREGATE LIABILITY FOR ANY CLAIM ARISING OUT OF OR RELATING TO THE SERVICE WILL NOT EXCEED THE GREATER OF (a) THE AMOUNT YOU PAID US IN THE TWELVE MONTHS BEFORE THE EVENT GIVING RISE TO THE CLAIM, OR (b) US$50.
+            </p>
+            <p className="text-gray-600 leading-relaxed mt-3">
+              Nothing in this section limits liability that cannot be limited under applicable law, including for death or personal injury caused by our negligence, for fraud, or for any other liability that cannot be excluded under the law that governs your relationship with us.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">13. Termination</h2>
+            <p className="text-gray-600 leading-relaxed">
+              You may end these Terms at any time by deleting your account from inside the app (Settings &rarr; Delete Account). Deletion is immediate and hard &mdash; see the Privacy Policy for the retention details that apply after deletion.
+            </p>
+            <p className="text-gray-600 leading-relaxed mt-3">
+              We may suspend or terminate your account if you violate these Terms, if we are required to by law, or if we discontinue the Service. Provisions that by their nature should survive termination &mdash; including Sections 5 (acceptable use), 8 (intellectual property), 11 (warranty disclaimer), 12 (liability), 14 (dispute resolution), and 15 (governing law) &mdash; will survive.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">14. Disputes</h2>
+            <h3 className="text-lg font-semibold text-[#1C1F26] mt-4 mb-2">14.1 Informal resolution first</h3>
+            <p className="text-gray-600 leading-relaxed">
+              Before bringing a formal claim, please email{" "}
+              <a href="mailto:support@screentimehero.com" className="text-[#3A7BFA] hover:underline">support@screentimehero.com</a>
+              {" "}describing the issue. We will work in good faith to resolve it within 60 days.
+            </p>
+            <h3 className="text-lg font-semibold text-[#1C1F26] mt-4 mb-2">14.2 Arbitration and class-action waiver (United States)</h3>
+            <p className="text-gray-600 leading-relaxed">
+              If you are a U.S. resident and the informal process does not resolve the dispute, you and Screen Time Hero agree to resolve any dispute arising out of or relating to the Service or these Terms by binding individual arbitration administered by the American Arbitration Association under its Consumer Arbitration Rules, rather than in court, except that you may bring claims in small-claims court if they qualify. You and Screen Time Hero each waive the right to a jury trial and the right to participate in a class action, class arbitration, or representative proceeding. The Federal Arbitration Act governs the interpretation and enforcement of this section.
+            </p>
+            <p className="text-gray-600 leading-relaxed mt-3">
+              You may opt out of this arbitration agreement by emailing{" "}
+              <a href="mailto:support@screentimehero.com" className="text-[#3A7BFA] hover:underline">support@screentimehero.com</a>
+              {" "}within 30 days of first accepting these Terms with the subject line &quot;Arbitration Opt-Out&quot; and your account email. Opting out will not affect any other part of these Terms.
+            </p>
+            <h3 className="text-lg font-semibold text-[#1C1F26] mt-4 mb-2">14.3 Consumers outside the United States</h3>
+            <p className="text-gray-600 leading-relaxed">
+              If you are a consumer residing outside the United States, nothing in Section 14.2 takes away the mandatory protections you have under the consumer-protection laws of your country of residence. You may bring claims in the courts of your country of residence if your local law requires it.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">15. Governing law and venue</h2>
+            <p className="text-gray-600 leading-relaxed">
+              These Terms are governed by the laws of the State of Delaware, United States, without regard to its conflict-of-law rules. Subject to Section 14, the exclusive venue for any claim that is not subject to arbitration is the state or federal courts located in Delaware, and you and Screen Time Hero submit to the personal jurisdiction of those courts. If you are a consumer residing outside the United States, the mandatory consumer-protection law of your country of residence still applies.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">16. Changes to these Terms</h2>
+            <p className="text-gray-600 leading-relaxed">
+              We may update these Terms from time to time. If the change is material we will update the effective date at the top of this page and, where practicable, notify you in-app or by email before the change takes effect. Your continued use of the Service after the change takes effect constitutes acceptance of the updated Terms; if you do not agree, stop using the Service and delete your account.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">17. Miscellaneous</h2>
+            <ul className="list-disc pl-6 text-gray-600 space-y-2">
+              <li><strong>Entire agreement.</strong> These Terms and the Privacy Policy are the entire agreement between you and Screen Time Hero about the Service and supersede any prior agreements on the same subject.</li>
+              <li><strong>Severability.</strong> If any provision is found unenforceable, the remaining provisions will continue in full force.</li>
+              <li><strong>No waiver.</strong> Our failure to enforce a provision is not a waiver of that or any other provision.</li>
+              <li><strong>Assignment.</strong> You may not assign these Terms without our written consent. We may assign these Terms to an affiliate or in connection with a merger, acquisition, or sale of assets.</li>
+              <li><strong>Force majeure.</strong> Neither party is liable for delay or failure caused by events beyond its reasonable control.</li>
+              <li><strong>Notices.</strong> We may provide notice to you through the app, email, or this website. Notices to us should go to{" "}
+                <a href="mailto:support@screentimehero.com" className="text-[#3A7BFA] hover:underline">support@screentimehero.com</a>.
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">18. Contact</h2>
+            <p className="text-gray-600 leading-relaxed">
+              Questions about these Terms:{" "}
+              <a href="mailto:support@screentimehero.com" className="text-[#3A7BFA] hover:underline">support@screentimehero.com</a>
             </p>
           </section>
         </div>

--- a/docs/PRIVACY-EU-UK-LAUNCH-ADDENDUM.md
+++ b/docs/PRIVACY-EU-UK-LAUNCH-ADDENDUM.md
@@ -1,0 +1,80 @@
+# EU/UK Launch — Privacy Policy swap-in
+
+Checklist + ready-to-paste copy for the day we expand Screen Time Hero into the EEA, UK, or Switzerland. The engineering-side GDPR compliance (self-export, self-delete, retention purge, in-app Art. 13/14 disclosure) is already shipped, so this is a policy + ops motion, not a code motion.
+
+---
+
+## Pre-launch checklist
+
+1. **Engage an Art. 27 representative.** Budget ~$700-1,000/yr for EU+UK combined. Vetted options:
+   - Prighter &mdash; established, decent UI
+   - GDPRLocal &mdash; often the cheapest legit option
+   - EDPO &mdash; law-firm-backed
+   - VeraSafe &mdash; enterprise-leaning, more expensive
+2. **Collect the rep&apos;s full address.** EU rep needs an EU-member-state street address; UK rep needs a UK address. Some vendors provide both under one plan; others are separate.
+3. **Update the Privacy Policy**: replace Section 14 with the copy below, restore Section 8&apos;s Irish DPC reference (it was trimmed at initial launch), and bump the Effective Date.
+4. **Update the Terms of Service**: governing-law Section 15 is fine as-is (Delaware + non-US consumer carve-out). No changes required.
+5. **App Store territory update**: re-submit `screentimehero` with EEA, UK, and Switzerland territories enabled.
+6. **Railway / Supabase**: no infrastructure change &mdash; we&apos;re already under SCCs + UK IDTA per Section 6 of the policy.
+7. **Communicate the change** to existing users at least 30 days before activating EU/UK availability (Section 12 notice requirement).
+
+---
+
+## Section 14 swap-in (replaces the current &quot;Where the Service is offered&quot; block)
+
+```tsx
+<section>
+  <h2 className="text-2xl font-bold text-[#1C1F26] mb-3">14. EU / UK representative</h2>
+  <p className="text-gray-600 leading-relaxed">
+    Under Article 27 of the GDPR and Article 27 of the UK GDPR, we have
+    appointed a representative in the European Union and the United
+    Kingdom. If you are in the EEA, the UK, or Switzerland, you may
+    contact our representative directly for any question about how we
+    handle your personal information.
+  </p>
+  <div className="text-gray-600 leading-relaxed mt-3">
+    <p><strong>EU representative:</strong></p>
+    <p>
+      [Rep legal name]<br />
+      [Street address]<br />
+      [Postal code, City]<br />
+      [EU member state]<br />
+      Email: <a href="mailto:eu-rep@screentimehero.com" className="text-[#3A7BFA] hover:underline">eu-rep@screentimehero.com</a>
+    </p>
+    <p className="mt-3"><strong>UK representative:</strong></p>
+    <p>
+      [Rep legal name]<br />
+      [Street address]<br />
+      [Postal code, City]<br />
+      United Kingdom<br />
+      Email: <a href="mailto:uk-rep@screentimehero.com" className="text-[#3A7BFA] hover:underline">uk-rep@screentimehero.com</a>
+    </p>
+  </div>
+</section>
+```
+
+## Section 8 augmentation (add Irish DPC reference back to the complaints bullet)
+
+The current complaints bullet reads:
+
+> **Lodge a complaint** with your local supervisory authority. In the UK it is the Information Commissioner&apos;s Office (ico.org.uk).
+
+Replace with:
+
+> **Lodge a complaint** with your local supervisory authority. In Ireland (where our EU representative is located) the authority is the Data Protection Commission (dataprotection.ie). In the UK it is the Information Commissioner&apos;s Office (ico.org.uk).
+
+(Swap &quot;Ireland&quot; for the actual member state of the chosen EU rep.)
+
+## Section 1 scope paragraph
+
+The current first paragraph ends with:
+
+> Screen Time Hero is the data controller / business for the personal information described in this policy.
+
+No change required &mdash; this is already accurate globally.
+
+---
+
+## Routing the rep inboxes
+
+Set up `eu-rep@screentimehero.com` and `uk-rep@screentimehero.com` to forward to the vendor&apos;s ticketing queue (most vendors provide this). Keep the addresses stable even if we change vendors, so the published Privacy Policy doesn&apos;t need to be re-issued every contract renewal.


### PR DESCRIPTION
## Summary

Rewrites both \`/privacy\` and \`/terms\` to meet the disclosures required for a global launch. Pairs with the engineering work already landed on the iOS app (parent self-export/delete, per-child Data & Privacy, privacy manifest, retention policy).

This is the C1-C4 block of the global launch punch list. Closes the content gap; the only remaining item is legal review.

## Privacy Policy highlights

- Controller identity and GDPR legal-basis table (Art. 13)
- COPPA section reflecting shipped mechanisms (email-confirmation VPC, in-app parental review/correct/delete/withdraw)
- Complete processor list: Supabase, Railway, Vercel, RevenueCat, Apple, Google, Resend, Twilio
- International-transfer section citing SCCs + UK IDTA
- Retention table matching \`docs/DATA-RETENTION.md\` 1:1
- Your-rights section pointing at the actual in-app surfaces (Settings > Download my data / Delete Account, per-child Data & Privacy)
- CCPA statutory-category breakdown + explicit no-sale / no-sharing / no-minors-under-16 statement
- Tracking section confirming no analytics SDKs, no ATT, no DNT response needed (matches \`PrivacyInfo.xcprivacy\`)

## Terms of Service highlights

- Subscription section pinning billing, cancellation, refunds, and EEA/UK 14-day withdrawal to the Apple App Store flow
- Apple LAEULA incorporation, export-control representation, Apple as third-party beneficiary (App Store Review requirement)
- Section 4 references the in-app Download / Delete / Data & Privacy surfaces that actually exist
- DMCA takedown path for chore-proof photos (§512(c)(3) elements)
- Warranty and liability sections with EEA/UK consumer-rights carve-out for mandatory statutory protections
- Disputes: informal-resolution-first, AAA arbitration + class-action waiver for US consumers with a 30-day opt-out, explicit non-US consumer carve-out
- Governing law pinned to Delaware (placeholder &mdash; swap to whichever state matches the legal entity&apos;s registration)
- Standard boilerplate that was missing: entire agreement, severability, no waiver, assignment, force majeure, notices

## Call-outs before publishing

1. **EU / UK Art. 27 representative** &mdash; required under GDPR for non-EU controllers targeting the EU. Needs a designated rep (services like GDPRlocal, Prighter, or EU-REP provide this) with EU + UK addresses.
2. **Legal entity name** &mdash; both docs use \"Screen Time Hero\". If the controlling entity is a specific LLC/Inc, swap in the legal name consistently across both pages.
3. **Governing law state** (Terms Section 15) &mdash; currently Delaware. Swap to match the legal entity&apos;s registration.
4. **Effective dates** &mdash; both set to April 22, 2026 placeholder; update on publish.
5. **Lawyer pass** &mdash; these are drafted to match the shipped product and to cover the major statutory beats; they are not legal advice. A privacy/consumer/app lawyer should review, especially:
   - EU/UK Art. 27 rep designation
   - SCC + UK IDTA citations
   - Arbitration + class-action waiver wording and opt-out mechanics
   - EEA/UK consumer-rights carve-outs
   - Apple LAEULA clauses

## Test plan

- [ ] \`next build\` green
- [ ] \`/privacy\` and \`/terms\` render on preview deploy
- [ ] Tables render responsively on mobile (overflow-x-auto)
- [ ] \"Back to Home\" links work on both pages
- [ ] Cross-links between Privacy and Terms work
- [ ] Lawyer sign-off before merge to main